### PR TITLE
Add plot background colouring option

### DIFF
--- a/src/DefaultEditor.js
+++ b/src/DefaultEditor.js
@@ -181,7 +181,8 @@ class DefaultEditor extends Component {
             />
             <CanvasSize label={_('Fixed Width')} attr="width" units="px" />
             <CanvasSize label={_('Fixed Height')} attr="height" units="px" />
-            <ColorPicker label={_('Color')} attr="paper_bgcolor" />
+            <ColorPicker label={_('Plot Background')} attr="plot_bgcolor" />
+            <ColorPicker label={_('Margin Color')} attr="paper_bgcolor" />
           </Fold>
           <Fold name={_('Title and Fonts')}>
             <Section name={_('Title')}>


### PR DESCRIPTION
closes: #180 
![screen shot 2018-01-02 at 9 49 44 pm](https://user-images.githubusercontent.com/4257572/34507725-ffb13430-f006-11e7-9164-4b0f47d732a6.png)

it's the same naming as on plot.ly/create
![screen shot 2018-01-02 at 9 52 43 pm](https://user-images.githubusercontent.com/4257572/34507757-539f40be-f007-11e7-8924-b3c1995d28e0.png)


ready for review @bpostlethwaite 
  