### PR TITLE
Fix for axes types not updating with new data types fixes #103

### DIFF
--- a/src/PlotlyEditor.js
+++ b/src/PlotlyEditor.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import dictionaries from './locales';
 import {bem} from './lib';
-import {noShame} from './shame';
+import {noShame, maybeClearAxisTypes} from './shame';
 import {EDITOR_ACTIONS} from './lib/constants';
 import isNumeric from 'fast-isnumeric';
 import nestedProperty from 'plotly.js/src/lib/nested_property';
@@ -60,6 +60,11 @@ class PlotlyEditor extends Component {
         if (this.props.onUpdateTraces) {
           this.props.onUpdateTraces(payload);
         }
+
+        // until we start utilizing Plotly.react in `react-plotly.js`
+        // force clear axes types when a `src` has changed.
+        maybeClearAxisTypes(graphDiv, payload.traceIndexes, payload.update);
+
         for (let i = 0; i < payload.traceIndexes.length; i++) {
           for (const attr in payload.update) {
             const traceIndex = payload.traceIndexes[i];

--- a/src/shame.js
+++ b/src/shame.js
@@ -1,12 +1,51 @@
 /*
  * DELETE THIS FILE. EVERYTHING NEEDS TO FIND A HOME.
  */
-import {list} from 'plotly.js/src/plots/cartesian/axis_ids';
+import {list, getFromId} from 'plotly.js/src/plots/cartesian/axis_ids';
+import nestedProperty from 'plotly.js/src/lib/nested_property';
 
 export function noShame(opts) {
   if (opts.plotly && !opts.plotly.Axes) {
-    opts.plotly.Axes = {
-      list,
-    };
+    opts.plotly.Axes = {list};
+  }
+}
+
+// Temporary fix for:
+// https://github.com/plotly/react-plotly.js-editor/issues/103
+// We should be able to remove this once the plotly.react method has
+// been integrated into react-plotly.js and released:
+// https://github.com/plotly/react-plotly.js/issues/2
+export const maybeClearAxisTypes = (graphDiv, traceIndexes, update) => {
+  if (!Array.isArray(graphDiv._fullData)) {
+    return;
+  }
+  let hasSrc = false;
+  for (const key in update) {
+    if (key.substr(key.length - 3) === 'src') {
+      hasSrc = true;
+    }
+  }
+  if (hasSrc) {
+    clearAxisTypes(graphDiv, traceIndexes);
+  }
+};
+
+const axLetters = ['x', 'y', 'z'];
+function clearAxisTypes(gd, traces) {
+  for (let i = 0; i < traces.length; i++) {
+    const trace = gd._fullData[i];
+    for (let j = 0; j < 3; j++) {
+      const type = axLetters[j];
+      const ax = getFromId(gd, trace[type + 'axis'] || type);
+
+      // Do not clear log type.
+      // Log type is never an auto result so must have been intentional.
+      // We are also skipping clearing 3D which could cause bugs with 3D.
+      if (ax && ax.type !== 'log') {
+        const axAttr = ax._name;
+        const typeAttr = axAttr + '.type';
+        nestedProperty(gd.layout, typeAttr).set(null);
+      }
+    }
   }
 }


### PR DESCRIPTION
fixes https://github.com/plotly/react-plotly.js-editor/issues/103
@alexcjohnson Ok the fix was pretty easy after a nights sleep. I winnowed away unnecessary code in the cleanAxisTypes function. It turns out if you ignore 3D (scenes) you don't need to make any calls to `_modules`. That means we are working with pure functions which can be used statically. That also means this fix won't apply to 3D but that is a trade off I am willing to make since https://github.com/plotly/react-plotly.js/issues/2 will solve the issue for all cases.


  