### PR TITLE
Make panel component set the foldIndex prop on its direct Fold children

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-plotly.js-editor",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/DefaultEditor.js
+++ b/src/DefaultEditor.js
@@ -167,7 +167,7 @@ class DefaultEditor extends Component {
           </TraceAccordion>
         </Panel>
         <LayoutPanel group="Style" name={_('Layout')}>
-          <Fold name={_('Canvas')} key={0}>
+          <Fold name={_('Canvas')}>
             <Radio
               attr="autosize"
               options={[
@@ -180,7 +180,7 @@ class DefaultEditor extends Component {
             <ColorPicker label={_('Plot Background')} attr="plot_bgcolor" />
             <ColorPicker label={_('Margin Color')} attr="paper_bgcolor" />
           </Fold>
-          <Fold name={_('Title and Fonts')} key={1}>
+          <Fold name={_('Title and Fonts')}>
             <Section name={_('Title')}>
               <MultiFormatTextEditor attr="title" />
               <FontSelector
@@ -205,7 +205,7 @@ class DefaultEditor extends Component {
               <ColorPicker label={_('Font Color')} attr="font.color" />
             </Section>
           </Fold>
-          <Fold name={_('Margins and Padding')} key={2}>
+          <Fold name={_('Margins and Padding')}>
             <Numeric label={_('Top')} attr="margin.t" units="px" />
             <Numeric label={_('Bottom')} attr="margin.b" units="px" />
             <Numeric label={_('Left')} attr="margin.l" units="px" />
@@ -293,7 +293,7 @@ class DefaultEditor extends Component {
           </AnnotationAccordion>
         </LayoutPanel>
         <LayoutPanel group="Style" name={_('Axes')}>
-          <AxesFold name={_('Titles')} key={0}>
+          <AxesFold name={_('Titles')}>
             <AxesSelector />
             <MultiFormatTextEditor attr="title" />
             <FontSelector label={_('Typeface')} attr="titlefont.family" />
@@ -301,7 +301,7 @@ class DefaultEditor extends Component {
             <ColorPicker label={_('Font Color')} attr="titlefont.color" />
           </AxesFold>
 
-          <AxesFold name={_('Range')} key={1}>
+          <AxesFold name={_('Range')}>
             <AxesSelector />
             <Section name={_('Selection')}>
               <Radio
@@ -323,10 +323,10 @@ class DefaultEditor extends Component {
             </Section>
           </AxesFold>
 
-          <AxesFold name={_('Lines')} key={2}>
+          <AxesFold name={_('Lines')}>
             <AxesSelector />
           </AxesFold>
-          <AxesFold name={_('Tick Labels')} key={3}>
+          <AxesFold name={_('Tick Labels')}>
             <AxesSelector />
             <Section name={_('Tick Labels')}>
               <FontSelector label={_('Typeface')} attr="tickfont.family" />
@@ -334,18 +334,18 @@ class DefaultEditor extends Component {
               <ColorPicker label={_('Font Color')} attr="tickfont.color" />
             </Section>
           </AxesFold>
-          <AxesFold name={_('Tick Markers')} key={4}>
+          <AxesFold name={_('Tick Markers')}>
             <AxesSelector />
           </AxesFold>
-          <AxesFold name={_('Zoom Interactivity')} key={5}>
+          <AxesFold name={_('Zoom Interactivity')}>
             <AxesSelector />
           </AxesFold>
-          <AxesFold name={_('Layout')} key={6}>
+          <AxesFold name={_('Layout')}>
             <AxesSelector />
           </AxesFold>
         </LayoutPanel>
         <LayoutPanel group="Style" name={_('Legend')}>
-          <Fold hideHeader key={0}>
+          <Fold hideHeader>
             <Section name={_('Legend')}>
               <Radio
                 attr="showlegend"

--- a/src/DefaultEditor.js
+++ b/src/DefaultEditor.js
@@ -167,7 +167,7 @@ class DefaultEditor extends Component {
           </TraceAccordion>
         </Panel>
         <LayoutPanel group="Style" name={_('Layout')}>
-          <Fold name={_('Canvas')} foldIndex={0} key={0}>
+          <Fold name={_('Canvas')} key={0}>
             <Radio
               attr="autosize"
               options={[
@@ -180,7 +180,7 @@ class DefaultEditor extends Component {
             <ColorPicker label={_('Plot Background')} attr="plot_bgcolor" />
             <ColorPicker label={_('Margin Color')} attr="paper_bgcolor" />
           </Fold>
-          <Fold name={_('Title and Fonts')} foldIndex={1} key={1}>
+          <Fold name={_('Title and Fonts')} key={1}>
             <Section name={_('Title')}>
               <MultiFormatTextEditor attr="title" />
               <FontSelector
@@ -205,7 +205,7 @@ class DefaultEditor extends Component {
               <ColorPicker label={_('Font Color')} attr="font.color" />
             </Section>
           </Fold>
-          <Fold name={_('Margins and Padding')} foldIndex={2} key={2}>
+          <Fold name={_('Margins and Padding')} key={2}>
             <Numeric label={_('Top')} attr="margin.t" units="px" />
             <Numeric label={_('Bottom')} attr="margin.b" units="px" />
             <Numeric label={_('Left')} attr="margin.l" units="px" />
@@ -293,7 +293,7 @@ class DefaultEditor extends Component {
           </AnnotationAccordion>
         </LayoutPanel>
         <LayoutPanel group="Style" name={_('Axes')}>
-          <AxesFold name={_('Titles')} foldIndex={0} key={0}>
+          <AxesFold name={_('Titles')} key={0}>
             <AxesSelector />
             <MultiFormatTextEditor attr="title" />
             <FontSelector label={_('Typeface')} attr="titlefont.family" />
@@ -301,7 +301,7 @@ class DefaultEditor extends Component {
             <ColorPicker label={_('Font Color')} attr="titlefont.color" />
           </AxesFold>
 
-          <AxesFold name={_('Range')} foldIndex={1} key={1}>
+          <AxesFold name={_('Range')} key={1}>
             <AxesSelector />
             <Section name={_('Selection')}>
               <Radio
@@ -323,10 +323,10 @@ class DefaultEditor extends Component {
             </Section>
           </AxesFold>
 
-          <AxesFold name={_('Lines')} foldIndex={2} key={2}>
+          <AxesFold name={_('Lines')} key={2}>
             <AxesSelector />
           </AxesFold>
-          <AxesFold name={_('Tick Labels')} foldIndex={3} key={3}>
+          <AxesFold name={_('Tick Labels')} key={3}>
             <AxesSelector />
             <Section name={_('Tick Labels')}>
               <FontSelector label={_('Typeface')} attr="tickfont.family" />
@@ -334,18 +334,18 @@ class DefaultEditor extends Component {
               <ColorPicker label={_('Font Color')} attr="tickfont.color" />
             </Section>
           </AxesFold>
-          <AxesFold name={_('Tick Markers')} foldIndex={4} key={4}>
+          <AxesFold name={_('Tick Markers')} key={4}>
             <AxesSelector />
           </AxesFold>
-          <AxesFold name={_('Zoom Interactivity')} foldIndex={5} key={5}>
+          <AxesFold name={_('Zoom Interactivity')} key={5}>
             <AxesSelector />
           </AxesFold>
-          <AxesFold name={_('Layout')} foldIndex={6} key={6}>
+          <AxesFold name={_('Layout')} key={6}>
             <AxesSelector />
           </AxesFold>
         </LayoutPanel>
         <LayoutPanel group="Style" name={_('Legend')}>
-          <Fold hideHeader foldIndex={0} key={0}>
+          <Fold hideHeader key={0}>
             <Section name={_('Legend')}>
               <Radio
                 attr="showlegend"

--- a/src/components/containers/Panel.js
+++ b/src/components/containers/Panel.js
@@ -90,7 +90,11 @@ export default class Panel extends Component {
       if (Array.isArray(children)) {
         children = children.map((child, index) => {
           if (child.type.displayName.indexOf('Fold') >= 0) {
-            return cloneElement(child, {...child.props, foldIndex: index, key: index});
+            return cloneElement(child, {
+              ...child.props,
+              foldIndex: index,
+              key: index,
+            });
           }
           return child;
         });

--- a/src/components/containers/Panel.js
+++ b/src/components/containers/Panel.js
@@ -90,7 +90,7 @@ export default class Panel extends Component {
       if (Array.isArray(children)) {
         children = children.map((child, index) => {
           if (child.type.displayName.indexOf('Fold') >= 0) {
-            return cloneElement(child, {...child.props, foldIndex: index});
+            return cloneElement(child, {...child.props, foldIndex: index, key: index});
           }
           return child;
         });

--- a/src/components/containers/Panel.js
+++ b/src/components/containers/Panel.js
@@ -1,6 +1,6 @@
 import PanelHeader from './PanelHeader';
 import PropTypes from 'prop-types';
-import React, {Component} from 'react';
+import React, {Component, cloneElement} from 'react';
 import update from 'immutability-helper';
 import {bem} from 'lib';
 
@@ -63,7 +63,7 @@ export default class Panel extends Component {
   }
 
   render() {
-    const {visible, children} = this.props;
+    const {visible} = this.props;
     const {individualFoldStates, nbOfFolds} = this.state;
     const hasOpen =
       individualFoldStates.length > 0 &&
@@ -71,6 +71,7 @@ export default class Panel extends Component {
     const {onUpdate, layout, updateContainer} = this.context;
 
     if (visible) {
+      let children = this.props.children;
       let action = null;
       let onAction = () => {};
 
@@ -84,6 +85,15 @@ export default class Panel extends Component {
         action = 'addAnnotation';
         onAction = () =>
           children.type.prototype.addAnnotation(layout, updateContainer);
+      }
+
+      if (Array.isArray(children)) {
+        children = children.map((child, index) => {
+          if (child.type.displayName.indexOf('Fold') >= 0) {
+            return cloneElement(child, {...child.props, foldIndex: index});
+          }
+          return child;
+        });
       }
 
       return (

--- a/src/styles/components/containers/_panel.scss
+++ b/src/styles/components/containers/_panel.scss
@@ -21,7 +21,7 @@
     &__collapse {
       font-size: var(--font-size-medium);
       float: left;
-      color: var(--color-rhino-core);
+      color: var(--color-text-base);
       display: flex;
       align-items: center;
       height: 100%;
@@ -29,7 +29,7 @@
       svg {
         width: 16px !important;
         height: 16px !important;
-        fill: var(--color-rhino-core);
+        fill: var(--color-text-light);
         padding-right: 3px;
       }
     }


### PR DESCRIPTION
These folds are going to cause issues and at some point we're going to decide where to draw the line on what we're supporting and not. 

React dom tree inspection is not that straight forward. When I try to inspect the children of Panel, for example, I'm not able to see the folds as children. It seems like they're not rendered yet and so don't show up in props.children

Because there doesn't seem to be a consistent way of checking if a panel is going to render Folds, I'm making the panel component check if folds are present with document.getElementsByClassName('fold'), this is how I'm currently able to somehow reliable tell if a Panel has Folds, build a state for Folds, and then make each Fold, with an index, check the state it should have through context.

I'm setting foldIndex for each trace in Accordions directly. But it does seem a little cumbersome to have to set foldIndex by hand in situations where Folds are direct children of the Panel.

This pr fixes that by setting a foldIndex on first level children of the Panel component. I'm not venturing into recursively trying to inspect first level children as it didn't consistently work for me when I was trying to do so with Accordions.

```
<Panel>
   <Fold/>
</Panel>
```

would this work for you @bpostlethwaite ?
I don't currently have a better solution to propose.