### PR TITLE
hardcode displayNames to survive minification

### DIFF
--- a/src/components/containers/AnnotationAccordion.js
+++ b/src/components/containers/AnnotationAccordion.js
@@ -46,6 +46,8 @@ class AnnotationAccordion extends Component {
   }
 }
 
+AnnotationAccordion.displayName = 'AnnotationAccordion';
+
 AnnotationAccordion.contextTypes = {
   layout: PropTypes.object,
 };

--- a/src/components/containers/Fold.js
+++ b/src/components/containers/Fold.js
@@ -94,6 +94,8 @@ class Fold extends Component {
   }
 }
 
+Fold.displayName = 'Fold';
+
 Fold.propTypes = {
   canDelete: PropTypes.bool,
   children: PropTypes.node,

--- a/src/components/containers/Panel.js
+++ b/src/components/containers/Panel.js
@@ -53,7 +53,7 @@ export default class Panel extends Component {
     return (
       children &&
       !Array.isArray(children) &&
-      children.type.name === 'AnnotationAccordion'
+      children.type.displayName.indexOf('AnnotationAccordion') >= 0
     );
   }
 

--- a/src/components/containers/TraceAccordion.js
+++ b/src/components/containers/TraceAccordion.js
@@ -64,6 +64,8 @@ class TraceAccordion extends Component {
   }
 }
 
+TraceAccordion.displayName = 'TraceAccordion';
+
 TraceAccordion.contextTypes = {
   data: PropTypes.array,
   fullData: PropTypes.array,


### PR DESCRIPTION
Fix for #232.

It's not ideal but this is what it takes for component names to survive minification, which they need to so that we can identify them in `Panel.js` for stuff like collapse-all and +Traces