### PR TITLE
autosize snaps dimensions back to defaults

### DIFF
--- a/examples/async-data/package.json
+++ b/examples/async-data/package.json
@@ -7,8 +7,8 @@
     "plotly.js": "^1.32.0",
     "react": "^15.6.1",
     "react-dom": "^15.6.1",
-    "react-plotly.js": "^1.0.4",
     "react-plotly.js-editor": "0.5.1",
+    "react-plotly.js": "^1.2.0",
     "react-scripts": "1.0.17"
   },
   "scripts": {

--- a/examples/custom/package.json
+++ b/examples/custom/package.json
@@ -6,8 +6,8 @@
     "plotly.js": "^1.32.0",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "react-plotly.js": "^1.0.4",
     "react-plotly.js-editor": "0.5.1",
+    "react-plotly.js": "^1.2.0",
     "react-scripts": "1.0.17"
   },
   "scripts": {

--- a/examples/redux/package.json
+++ b/examples/redux/package.json
@@ -7,8 +7,8 @@
     "prop-types": "^15.6.0",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "react-plotly.js": "^1.0.4",
     "react-plotly.js-editor": "0.5.1",
+    "react-plotly.js": "^1.2.0",
     "react-redux": "^5.0.6",
     "react-scripts": "1.0.17",
     "redux": "^3.7.2"

--- a/examples/simple/package.json
+++ b/examples/simple/package.json
@@ -6,8 +6,8 @@
     "plotly.js": "^1.32.0",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "react-plotly.js": "^1.0.4",
     "react-plotly.js-editor": "0.5.1",
+    "react-plotly.js": "^1.2.0",
     "react-scripts": "1.0.17"
   },
   "scripts": {

--- a/examples/simple/src/App.js
+++ b/examples/simple/src/App.js
@@ -49,14 +49,16 @@ class App extends Component {
           dataSourceOptions={dataSourceOptions}
           plotly={plotly}
         />
-        <div className="app__main">
+        <div className="app__main" style={{width: '100%', height: '100%'}}>
           <Plot
             debug
+            useResizeHandler
             data={this.state.graphDiv.data}
             layout={this.state.graphDiv.layout}
             onUpdate={this.handlePlotUpdate.bind(this)}
             onInitialized={this.handlePlotUpdate.bind(this)}
             revision={this.state.plotRevision}
+            style={{width: '100%', height: '100%'}}
           />
         </div>
       </div>

--- a/src/components/fields/derived.js
+++ b/src/components/fields/derived.js
@@ -10,9 +10,12 @@ import {
 
 export const CanvasSize = connectToContainer(UnconnectedNumeric, {
   modifyPlotProps: (props, context, plotProps) => {
-    const {fullContainer} = plotProps;
+    const {fullContainer, updateContainer, container} = plotProps;
     if (plotProps.isVisible && fullContainer && fullContainer.autosize) {
       plotProps.isVisible = false;
+      if (container[props.attr]) {
+        updateContainer({[props.attr]: {}});
+      }
     }
   },
 });


### PR DESCRIPTION
Possible fix for https://github.com/plotly/plotly.js-batch-reporter/issues/23