### PR TITLE
add afterTracesUpdate hook

### DIFF
--- a/src/PlotlyEditor.js
+++ b/src/PlotlyEditor.js
@@ -56,8 +56,8 @@ class PlotlyEditor extends Component {
 
     switch (type) {
       case EDITOR_ACTIONS.UPDATE_TRACES:
-        if (this.props.onUpdateTraces) {
-          this.props.onUpdateTraces(payload);
+        if (this.props.beforeUpdateTraces) {
+          this.props.beforeUpdateTraces(payload);
         }
 
         // until we start utilizing Plotly.react in `react-plotly.js`
@@ -74,14 +74,17 @@ class PlotlyEditor extends Component {
             }
           }
         }
+        if (this.props.afterUpdateTraces) {
+          this.props.afterUpdateTraces(payload);
+        }
         if (this.props.onUpdate) {
           this.props.onUpdate();
         }
         break;
 
       case EDITOR_ACTIONS.UPDATE_LAYOUT:
-        if (this.props.onUpdateLayout) {
-          this.props.onUpdateLayout(payload);
+        if (this.props.beforeUpdateLayout) {
+          this.props.beforeUpdateLayout(payload);
         }
         for (const attr in payload.update) {
           const prop = nestedProperty(graphDiv.layout, attr);
@@ -90,27 +93,36 @@ class PlotlyEditor extends Component {
             prop.set(value);
           }
         }
+        if (this.props.afterUpdateLayout) {
+          this.props.afterUpdateLayout(payload);
+        }
         if (this.props.onUpdate) {
           this.props.onUpdate();
         }
         break;
 
       case EDITOR_ACTIONS.ADD_TRACE:
-        if (this.props.onAddTrace) {
-          this.props.onAddTrace(payload);
+        if (this.props.beforeAddTrace) {
+          this.props.beforeAddTrace(payload);
         }
         graphDiv.data.push({x: [], y: [], type: 'scatter', mode: 'markers'});
+        if (this.props.afterAddTrace) {
+          this.props.afterAddTrace(payload);
+        }
         if (this.props.onUpdate) {
           this.props.onUpdate();
         }
         break;
 
       case EDITOR_ACTIONS.DELETE_TRACE:
-        if (this.props.onDeleteTrace) {
-          this.props.onDeleteTrace(payload);
-        }
         if (payload.traceIndexes && payload.traceIndexes.length) {
+          if (this.props.beforeDeleteTrace) {
+            this.props.beforeDeleteTrace(payload);
+          }
           graphDiv.data.splice(payload.traceIndexes[0], 1);
+          if (this.props.afterDeleteTrace) {
+            this.props.afterDeleteTrace(payload);
+          }
           if (this.props.onUpdate) {
             this.props.onUpdate();
           }
@@ -118,11 +130,14 @@ class PlotlyEditor extends Component {
         break;
 
       case EDITOR_ACTIONS.DELETE_ANNOTATION:
-        if (this.props.onDeleteAnnotation) {
-          this.props.onDeleteAnnotation(payload);
-        }
         if (isNumeric(payload.annotationIndex)) {
+          if (this.props.beforeDeleteAnnotation) {
+            this.props.beforeDeleteAnnotation(payload);
+          }
           graphDiv.layout.annotations.splice(payload.annotationIndex, 1);
+          if (this.props.afterDeleteAnnotation) {
+            this.props.afterDeleteAnnotation(payload);
+          }
           if (this.props.onUpdate) {
             this.props.onUpdate();
           }
@@ -152,23 +167,28 @@ class PlotlyEditor extends Component {
 }
 
 PlotlyEditor.propTypes = {
+  afterAddTrace: PropTypes.func,
+  afterDeleteAnnotation: PropTypes.func,
+  afterDeleteTrace: PropTypes.func,
+  afterUpdateLayout: PropTypes.func,
+  afterUpdateTraces: PropTypes.func,
+  beforeAddTrace: PropTypes.func,
+  beforeDeleteAnnotation: PropTypes.func,
+  beforeDeleteTrace: PropTypes.func,
+  beforeUpdateLayout: PropTypes.func,
+  beforeUpdateTraces: PropTypes.func,
   children: PropTypes.node,
   className: PropTypes.string,
-  dataSources: PropTypes.object,
+  dataSourceOptionRenderer: PropTypes.func,
   dataSourceOptions: PropTypes.array,
   dataSourceValueRenderer: PropTypes.func,
-  dataSourceOptionRenderer: PropTypes.func,
   dictionaries: PropTypes.object,
+  dataSources: PropTypes.object,
   graphDiv: PropTypes.object,
   locale: PropTypes.string,
-  revision: PropTypes.any,
   onUpdate: PropTypes.func,
-  onUpdateTraces: PropTypes.func,
-  onUpdateLayout: PropTypes.func,
-  onAddTrace: PropTypes.func,
-  onDeleteTrace: PropTypes.func,
-  onDeleteAnnotation: PropTypes.func,
   plotly: PropTypes.object,
+  revision: PropTypes.any,
 };
 
 PlotlyEditor.defaultProps = {

--- a/src/components/containers/__tests__/AnnotationAccordion-test.js
+++ b/src/components/containers/__tests__/AnnotationAccordion-test.js
@@ -29,9 +29,9 @@ describe('<AnnotationAccordion>', () => {
 
   it('can add annotations', () => {
     const fixture = fixtures.scatter();
-    const onUpdateLayout = jest.fn();
+    const beforeUpdateLayout = jest.fn();
     const editor = mount(
-      <TestEditor {...{...fixture, onUpdateLayout}}>
+      <TestEditor {...{...fixture, beforeUpdateLayout}}>
         <LayoutPanel name="Annotations">
           <AnnotationAccordion canAdd>
             <Numeric attr="textangle" />
@@ -42,7 +42,7 @@ describe('<AnnotationAccordion>', () => {
 
     editor.find('button.js-add-annotation-button').simulate('click');
 
-    const payload = onUpdateLayout.mock.calls[0][0];
+    const payload = beforeUpdateLayout.mock.calls[0][0];
     expect(payload.update).toEqual({'annotations[0]': {text: 'new text'}});
   });
 
@@ -50,9 +50,9 @@ describe('<AnnotationAccordion>', () => {
     const fixture = fixtures.scatter({
       layout: {annotations: [{text: 'hodor'}, {text: 'rodoh'}]},
     });
-    const onDeleteAnnotation = jest.fn();
+    const beforeDeleteAnnotation = jest.fn();
     const editor = mount(
-      <TestEditor {...{...fixture, onDeleteAnnotation}}>
+      <TestEditor {...{...fixture, beforeDeleteAnnotation}}>
         <LayoutPanel name="Annotations">
           <AnnotationAccordion canAdd>
             <Numeric attr="textangle" />
@@ -65,7 +65,7 @@ describe('<AnnotationAccordion>', () => {
       .at(0)
       .simulate('click');
 
-    const update = onDeleteAnnotation.mock.calls[0][0];
+    const update = beforeDeleteAnnotation.mock.calls[0][0];
     expect(update.annotationIndex).toBe(0);
   });
 });

--- a/src/components/containers/__tests__/Fold-test.js
+++ b/src/components/containers/__tests__/Fold-test.js
@@ -32,9 +32,9 @@ describe('<Fold>', () => {
   });
 
   it('calls deleteContainer when function present and canDelete is true', () => {
-    const onDeleteTrace = jest.fn();
+    const beforeDeleteTrace = jest.fn();
     mount(
-      <TestEditor {...fixtures.scatter()} onDeleteTrace={onDeleteTrace}>
+      <TestEditor {...fixtures.scatter()} beforeDeleteTrace={beforeDeleteTrace}>
         <Panel>
           <TraceFold traceIndex={0} canDelete={true} foldIndex={0}>
             <Numeric attr="opacity" />
@@ -45,7 +45,7 @@ describe('<Fold>', () => {
       .find('.js-fold__delete')
       .simulate('click');
 
-    const payload = onDeleteTrace.mock.calls[0][0];
+    const payload = beforeDeleteTrace.mock.calls[0][0];
     expect(payload).toEqual({traceIndexes: [0]});
   });
 });

--- a/src/components/containers/__tests__/Layout-test.js
+++ b/src/components/containers/__tests__/Layout-test.js
@@ -28,10 +28,10 @@ Layouts.forEach(Layout => {
     });
 
     it(`sends updates to gd._layout`, () => {
-      const onUpdateLayout = jest.fn();
+      const beforeUpdateLayout = jest.fn();
       const wrapper = mount(
         <Editor
-          onUpdateLayout={onUpdateLayout}
+          beforeUpdateLayout={beforeUpdateLayout}
           {...fixtures.scatter({layout: {width: 100}})}
         >
           <Panel>
@@ -46,7 +46,7 @@ Layouts.forEach(Layout => {
 
       const widthUpdate = 200;
       wrapper.prop('onChange')(widthUpdate);
-      const payload = onUpdateLayout.mock.calls[0][0];
+      const payload = beforeUpdateLayout.mock.calls[0][0];
       expect(payload).toEqual({update: {width: widthUpdate}});
     });
   });

--- a/src/components/containers/__tests__/TraceAccordion-test.js
+++ b/src/components/containers/__tests__/TraceAccordion-test.js
@@ -22,9 +22,9 @@ describe('<TraceAccordion>', () => {
 
   it('can add traces', () => {
     const fixture = fixtures.scatter();
-    const onAddTrace = jest.fn();
+    const beforeAddTrace = jest.fn();
     const editor = mount(
-      <TestEditor {...{...fixture, onAddTrace}}>
+      <TestEditor {...{...fixture, beforeAddTrace}}>
         <Panel>
           <TraceAccordion canAdd>
             <Numeric attr="textangle" />
@@ -35,14 +35,14 @@ describe('<TraceAccordion>', () => {
 
     editor.find('button.js-add-trace-button').simulate('click');
 
-    expect(onAddTrace).toBeCalled();
+    expect(beforeAddTrace).toBeCalled();
   });
 
   it('can delete traces', () => {
     const fixture = fixtures.scatter({data: [{name: 'hodor'}]});
-    const onDeleteTrace = jest.fn();
+    const beforeDeleteTrace = jest.fn();
     const editor = mount(
-      <TestEditor {...{...fixture, onDeleteTrace}}>
+      <TestEditor {...{...fixture, beforeDeleteTrace}}>
         <Panel>
           <TraceAccordion canAdd>
             <Numeric attr="textangle" />
@@ -56,8 +56,8 @@ describe('<TraceAccordion>', () => {
       .at(0)
       .simulate('click');
 
-    expect(onDeleteTrace).toBeCalled();
-    const update = onDeleteTrace.mock.calls[0][0];
+    expect(beforeDeleteTrace).toBeCalled();
+    const update = beforeDeleteTrace.mock.calls[0][0];
     expect(update.traceIndexes[0]).toBe(0);
   });
 });

--- a/src/components/fields/__tests__/AnnotationRef-test.js
+++ b/src/components/fields/__tests__/AnnotationRef-test.js
@@ -32,15 +32,17 @@ describe('<AnnotationRef>', () => {
   });
 
   it('sends update for a[x|y]ref attr on [x|y]ref change', () => {
-    const onUpdateLayout = jest.fn();
+    const beforeUpdateLayout = jest.fn();
     const fixtureProps = fixtures.scatter({
       layout: {annotations: [{text: 'thor', ayref: 'y'}]},
     });
-    const drop = render({onUpdateLayout, ...fixtureProps}).find(DropdownWidget);
+    const drop = render({beforeUpdateLayout, ...fixtureProps}).find(
+      DropdownWidget
+    );
 
     drop.prop('onChange')('y2');
 
-    const {update} = onUpdateLayout.mock.calls[0][0];
+    const {update} = beforeUpdateLayout.mock.calls[0][0];
     expect(update).toEqual({
       'annotations[0].ayref': 'y2',
       'annotations[0].yref': 'y2',
@@ -48,28 +50,32 @@ describe('<AnnotationRef>', () => {
   });
 
   it('does not send update for a[x|y]ref attr on "paper" change', () => {
-    const onUpdateLayout = jest.fn();
+    const beforeUpdateLayout = jest.fn();
     const fixtureProps = fixtures.scatter({
       layout: {annotations: [{text: 'thor', ayref: 'y'}]},
     });
-    const drop = render({onUpdateLayout, ...fixtureProps}).find(DropdownWidget);
+    const drop = render({beforeUpdateLayout, ...fixtureProps}).find(
+      DropdownWidget
+    );
 
     drop.prop('onChange')('paper');
-    const {update} = onUpdateLayout.mock.calls[0][0];
+    const {update} = beforeUpdateLayout.mock.calls[0][0];
     expect(update).toEqual({
       'annotations[0].yref': 'paper',
     });
   });
 
   it('does not send update for a[x|y]ref when a[x|y]ref is pixel', () => {
-    const onUpdateLayout = jest.fn();
+    const beforeUpdateLayout = jest.fn();
     const fixtureProps = fixtures.scatter({
       layout: {annotations: [{text: 'thor', yref: 'y', ayref: 'pixel'}]},
     });
-    const drop = render({onUpdateLayout, ...fixtureProps}).find(DropdownWidget);
+    const drop = render({beforeUpdateLayout, ...fixtureProps}).find(
+      DropdownWidget
+    );
 
     drop.prop('onChange')('y2');
-    const {update} = onUpdateLayout.mock.calls[0][0];
+    const {update} = beforeUpdateLayout.mock.calls[0][0];
     expect(update).toEqual({
       'annotations[0].yref': 'y2',
     });

--- a/src/components/fields/__tests__/DataSelector-test.js
+++ b/src/components/fields/__tests__/DataSelector-test.js
@@ -35,11 +35,11 @@ describe('DataSelector', () => {
   it('uses gd.data dataSrc value not fullValue when arrayOk', () => {});
 
   it('calls updatePlot with srcAttr and data when present', () => {
-    const onUpdateTraces = jest.fn();
-    const wrapper = render({onUpdateTraces}).find(DropdownWidget);
-    onUpdateTraces.mockClear();
+    const beforeUpdateTraces = jest.fn();
+    const wrapper = render({beforeUpdateTraces}).find(DropdownWidget);
+    beforeUpdateTraces.mockClear();
     wrapper.prop('onChange')('y1');
-    expect(onUpdateTraces.mock.calls[0][0]).toEqual({
+    expect(beforeUpdateTraces.mock.calls[0][0]).toEqual({
       update: {xsrc: 'y1', x: [2, 3, 4]},
       traceIndexes: [0],
     });

--- a/src/components/fields/__tests__/TraceSelector-test.js
+++ b/src/components/fields/__tests__/TraceSelector-test.js
@@ -125,10 +125,10 @@ describe('TraceSelector', () => {
   });
 
   it('updates type=scatter mode=lines when type=line', () => {
-    const onUpdateTraces = jest.fn();
+    const beforeUpdateTraces = jest.fn();
     const editorProps = {
       ...fixtures.scatter({data: [{type: 'scatter', mode: 'markers'}]}),
-      onUpdateTraces,
+      beforeUpdateTraces,
       plotly,
     };
     const wrapper = mount(
@@ -142,7 +142,7 @@ describe('TraceSelector', () => {
     const innerDropdown = wrapper.find(Dropdown);
     innerDropdown.prop('onChange')('line');
 
-    const payload = onUpdateTraces.mock.calls[0][0];
+    const payload = beforeUpdateTraces.mock.calls[0][0];
     expect(payload.update).toEqual({
       fill: 'none',
       mode: 'lines',
@@ -151,10 +151,10 @@ describe('TraceSelector', () => {
   });
 
   it('updates type=scatter fill=tozeroy when type=area', () => {
-    const onUpdateTraces = jest.fn();
+    const beforeUpdateTraces = jest.fn();
     const editorProps = {
       ...fixtures.scatter({data: [{type: 'scatter', mode: 'markers'}]}),
-      onUpdateTraces,
+      beforeUpdateTraces,
       plotly,
     };
     const wrapper = mount(
@@ -168,7 +168,7 @@ describe('TraceSelector', () => {
     const innerDropdown = wrapper.find(Dropdown);
     innerDropdown.prop('onChange')('area');
 
-    const payload = onUpdateTraces.mock.calls[0][0];
+    const payload = beforeUpdateTraces.mock.calls[0][0];
     expect(payload.update).toEqual({fill: 'tozeroy', type: 'scatter'});
   });
 });

--- a/src/lib/__tests__/connectAnnotationToLayout-test.js
+++ b/src/lib/__tests__/connectAnnotationToLayout-test.js
@@ -6,7 +6,7 @@ import {connectLayoutToPlot, connectAnnotationToLayout} from '..';
 
 describe('connectAnnotationToLayout', () => {
   it('sends update to layout.annotation[index]', () => {
-    const onUpdateLayout = jest.fn();
+    const beforeUpdateLayout = jest.fn();
     const fixture = fixtures.scatter({
       layout: {annotations: [{text: 'hodor'}]},
     });
@@ -15,7 +15,7 @@ describe('connectAnnotationToLayout', () => {
     );
 
     mount(
-      <TestEditor {...{...fixture, onUpdateLayout}}>
+      <TestEditor {...{...fixture, beforeUpdateLayout}}>
         <ConnectedNumeric annotationIndex={0} label="Angle" attr="textangle" />
       </TestEditor>
     )
@@ -23,7 +23,7 @@ describe('connectAnnotationToLayout', () => {
       .find('.js-numeric-increase')
       .simulate('click');
 
-    const payload = onUpdateLayout.mock.calls[0][0];
+    const payload = beforeUpdateLayout.mock.calls[0][0];
     expect(payload.update).toEqual({'annotations[0].textangle': 1});
   });
 });

--- a/src/lib/__tests__/connectLayoutToPlot-test.js
+++ b/src/lib/__tests__/connectLayoutToPlot-test.js
@@ -30,10 +30,10 @@ Layouts.forEach(Layout => {
     });
 
     it(`sends updates to gd._layout`, () => {
-      const onUpdateLayout = jest.fn();
+      const beforeUpdateLayout = jest.fn();
       const wrapper = mount(
         <Editor
-          onUpdateLayout={onUpdateLayout}
+          beforeUpdateLayout={beforeUpdateLayout}
           {...fixtures.scatter({layout: {width: 100}})}
         >
           <Panel>
@@ -48,7 +48,7 @@ Layouts.forEach(Layout => {
 
       const widthUpdate = 200;
       wrapper.prop('onChange')(widthUpdate);
-      const payload = onUpdateLayout.mock.calls[0][0];
+      const payload = beforeUpdateLayout.mock.calls[0][0];
       expect(payload).toEqual({update: {width: widthUpdate}});
     });
 

--- a/src/lib/__tests__/connectTraceToPlot-test.js
+++ b/src/lib/__tests__/connectTraceToPlot-test.js
@@ -32,9 +32,9 @@ Traces.forEach(Trace => {
     });
 
     it('sends updates to gd.data', () => {
-      const onUpdateTraces = jest.fn();
+      const beforeUpdateTraces = jest.fn();
       const wrapper = mount(
-        <Editor onUpdateTraces={onUpdateTraces} {...fixtures.scatter()}>
+        <Editor beforeUpdateTraces={beforeUpdateTraces} {...fixtures.scatter()}>
           <Panel>
             <Trace traceIndex={0} foldIndex={0}>
               <Numeric label="Marker Size" attr="marker.size" />
@@ -47,7 +47,7 @@ Traces.forEach(Trace => {
 
       const sizeUpdate = 200;
       wrapper.prop('onChange')(sizeUpdate);
-      const payload = onUpdateTraces.mock.calls[0][0];
+      const payload = beforeUpdateTraces.mock.calls[0][0];
       expect(payload).toEqual({
         update: {'marker.size': sizeUpdate},
         traceIndexes: [0],

--- a/src/lib/__tests__/multiValued-test.js
+++ b/src/lib/__tests__/multiValued-test.js
@@ -36,7 +36,7 @@ describe('multiValued Numeric', () => {
   });
 
   it('uses multiValued defaultContainer as default increment value', () => {
-    const onUpdateLayout = jest.fn();
+    const beforeUpdateLayout = jest.fn();
     const xaxisLowerRange = -30;
     const fixtureProps = fixtures.scatter({
       layout: {xaxis: {range: [xaxisLowerRange, 3]}, yaxis: {range: [0, 3]}},
@@ -44,15 +44,15 @@ describe('multiValued Numeric', () => {
     const AxesNumeric = connectLayoutToPlot(connectAxesToLayout(Numeric));
 
     mount(
-      <TestEditor {...{...fixtureProps, onUpdateLayout, plotly}}>
+      <TestEditor {...{...fixtureProps, beforeUpdateLayout, plotly}}>
         <AxesNumeric attr="range[0]" defaultAxesTarget="allaxes" />
       </TestEditor>
     )
       .find('.js-numeric-increase')
       .simulate('click');
 
-    expect(onUpdateLayout).toBeCalled();
-    const payload = onUpdateLayout.mock.calls[0][0];
+    expect(beforeUpdateLayout).toBeCalled();
+    const payload = beforeUpdateLayout.mock.calls[0][0];
     expect(payload.update).toEqual({
       'xaxis.range[0]': xaxisLowerRange,
       'yaxis.range[0]': xaxisLowerRange,

--- a/src/lib/__tests__/nestedContainerConnections-test.js
+++ b/src/lib/__tests__/nestedContainerConnections-test.js
@@ -13,13 +13,13 @@ import {
 
 describe('Plot Connection', () => {
   it('can connect Field directly with full connection pipeline', () => {
-    const onUpdateLayout = jest.fn();
+    const beforeUpdateLayout = jest.fn();
     const fixtureProps = fixtures.scatter({layout: {xaxis: {range: [0, 10]}}});
     const LayoutAxesNumeric = connectLayoutToPlot(
       connectAxesToLayout(connectToContainer(Numeric))
     );
     mount(
-      <TestEditor {...{...fixtureProps, onUpdateLayout}}>
+      <TestEditor {...{...fixtureProps, beforeUpdateLayout}}>
         <LayoutAxesNumeric label="Min" attr="range[0]" />
       </TestEditor>
     )
@@ -28,19 +28,19 @@ describe('Plot Connection', () => {
       .find('.js-numeric-increase')
       .simulate('click');
 
-    expect(onUpdateLayout).toBeCalled();
-    const payload = onUpdateLayout.mock.calls[0][0];
+    expect(beforeUpdateLayout).toBeCalled();
+    const payload = beforeUpdateLayout.mock.calls[0][0];
     expect(payload).toEqual({update: {'xaxis.range[0]': 1}});
   });
 
   it('can connect to layout when connected within trace context', () => {
-    const onUpdateLayout = jest.fn();
+    const beforeUpdateLayout = jest.fn();
     const fixtureProps = fixtures.scatter({layout: {width: 10}});
     const TraceLayoutNumeric = connectTraceToPlot(
       connectLayoutToPlot(connectToContainer(Numeric))
     );
     mount(
-      <TestEditor {...{...fixtureProps, onUpdateLayout}}>
+      <TestEditor {...{...fixtureProps, beforeUpdateLayout}}>
         <TraceLayoutNumeric traceIndex={0} label="Width" attr="width" />
       </TestEditor>
     )
@@ -49,8 +49,8 @@ describe('Plot Connection', () => {
       .find('.js-numeric-increase')
       .simulate('click');
 
-    expect(onUpdateLayout).toBeCalled();
-    const payload = onUpdateLayout.mock.calls[0][0];
+    expect(beforeUpdateLayout).toBeCalled();
+    const payload = beforeUpdateLayout.mock.calls[0][0];
     expect(payload).toEqual({update: {width: 11}});
   });
 
@@ -84,7 +84,7 @@ describe('Plot Connection', () => {
   });
 
   it('can supplyPlotProps within <Section> and nested Layout and Trace', () => {
-    const onUpdateLayout = jest.fn();
+    const beforeUpdateLayout = jest.fn();
     const fixtureProps = fixtures.scatter({layout: {width: 10}});
     const TracePanel = connectTraceToPlot(Panel);
     const LayoutConnectedNumeric = connectLayoutToPlot(
@@ -99,7 +99,7 @@ describe('Plot Connection', () => {
     );
 
     mount(
-      <TestEditor {...{...fixtureProps, onUpdateLayout}}>
+      <TestEditor {...{...fixtureProps, beforeUpdateLayout}}>
         <TracePanel traceIndex={0}>
           <Section name="Canvas">
             <LayoutConnectedNumeric traceIndex={0} label="Width" attr="width" />
@@ -112,8 +112,8 @@ describe('Plot Connection', () => {
       .find('.js-numeric-increase')
       .simulate('click');
 
-    expect(onUpdateLayout).toBeCalled();
-    const payload = onUpdateLayout.mock.calls[0][0];
+    expect(beforeUpdateLayout).toBeCalled();
+    const payload = beforeUpdateLayout.mock.calls[0][0];
     expect(payload).toEqual({update: {width: 11}});
   });
 


### PR DESCRIPTION
@nicolaskruchten turns out the app I am working on needs a gd.data update event _after_ the update. That way I can collect all the next sources rather than figure out which of the previous sources will be updated and generating a new list (this is exactly what the editor does in its update routine).

Having a _before_ hook is useful. Do you think we should we add `after` hooks for every update method or introduce these as necessary?