### PR TITLE
 enables nested Panel/Fold/Panel/Fold

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-2": "^6.24.1",
     "babel-traverse": "^6.26.0",
+    "canvas": "^1.6.9",
     "classnames": "^2.2.5",
     "css-loader": "^0.28.9",
     "cssnano": "^3.10.0",

--- a/src/DefaultEditor.js
+++ b/src/DefaultEditor.js
@@ -9,16 +9,18 @@ import {
   StyleLegendPanel,
   StyleNotesPanel,
   StyleTracesPanel,
+  StyleColorbarsPanel,
 } from './default_panels';
 
 const DefaultEditor = ({localize: _}) => (
   <PanelMenuWrapper>
-    <GraphCreatePanel group="Graph" name="Create" />
-    <StyleTracesPanel group="Style" name="Traces" />
-    <StyleLayoutPanel group="Style" name={_('Layout')} />
-    <StyleNotesPanel group="Style" name={_('Notes')} />
-    <StyleAxesPanel group="Style" name={_('Axes')} />
-    <StyleLegendPanel group="Style" name={_('Legend')} />
+    <GraphCreatePanel group={_('Graph')} name={_('Create')} />
+    <StyleTracesPanel group={_('Style')} name={_('Traces')} />
+    <StyleLayoutPanel group={_('Style')} name={_('Layout')} />
+    <StyleNotesPanel group={_('Style')} name={_('Notes')} />
+    <StyleAxesPanel group={_('Style')} name={_('Axes')} />
+    <StyleLegendPanel group={_('Style')} name={_('Legend')} />
+    <StyleColorbarsPanel group={_('Style')} name={_('Color Bars')} />
   </PanelMenuWrapper>
 );
 

--- a/src/components/containers/AnnotationAccordion.js
+++ b/src/components/containers/AnnotationAccordion.js
@@ -1,7 +1,8 @@
 import Fold from './Fold';
+import TraceRequiredPanel from './TraceRequiredPanel';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
-import {connectAnnotationToLayout, bem} from 'lib';
+import {connectAnnotationToLayout} from 'lib';
 
 const AnnotationFold = connectAnnotationToLayout(Fold);
 
@@ -17,39 +18,38 @@ class AnnotationAccordion extends Component {
           key={i}
           annotationIndex={i}
           name={ann.text}
-          foldIndex={i}
           canDelete={canAdd}
         >
           {children}
         </AnnotationFold>
       ));
 
+    const addAction = {
+      label: 'Annotation',
+      handler: ({layout, updateContainer}) => {
+        let annotationIndex;
+        if (Array.isArray(layout.annotations)) {
+          annotationIndex = layout.annotations.length;
+        } else {
+          annotationIndex = 0;
+        }
+
+        const key = `annotations[${annotationIndex}]`;
+        const value = {text: 'new text'};
+
+        if (updateContainer) {
+          updateContainer({[key]: value});
+        }
+      },
+    };
+
     return (
-      <div className={bem('panel', 'content')}>{content ? content : null}</div>
+      <TraceRequiredPanel addAction={canAdd ? addAction : null}>
+        {content ? content : null}
+      </TraceRequiredPanel>
     );
   }
 }
-
-AnnotationAccordion.plotly_editor_traits = {
-  add_action: {
-    label: 'Annotation',
-    handler: ({layout, updateContainer}) => {
-      let annotationIndex;
-      if (Array.isArray(layout.annotations)) {
-        annotationIndex = layout.annotations.length;
-      } else {
-        annotationIndex = 0;
-      }
-
-      const key = `annotations[${annotationIndex}]`;
-      const value = {text: 'new text'};
-
-      if (updateContainer) {
-        updateContainer({[key]: value});
-      }
-    },
-  },
-};
 
 AnnotationAccordion.contextTypes = {
   layout: PropTypes.object,

--- a/src/components/containers/Fold.js
+++ b/src/components/containers/Fold.js
@@ -7,19 +7,18 @@ import {localize} from 'lib';
 
 class Fold extends Component {
   render() {
-    const {deleteContainer, individualFoldStates, toggleFold} = this.context;
+    const {deleteContainer} = this.context;
     const {
       canDelete,
       children,
       className,
-      foldIndex,
+      folded,
+      toggleFold,
       hideHeader,
       icon: Icon,
       isEmpty,
       name,
     } = this.props;
-
-    const folded = individualFoldStates[foldIndex];
 
     const doDelete = typeof deleteContainer === 'function' && canDelete;
 
@@ -56,7 +55,7 @@ class Fold extends Component {
     const icon = Icon ? <Icon className="fold__top__icon" /> : null;
 
     const foldHeader = !hideHeader && (
-      <div className={headerClass} onClick={() => toggleFold(foldIndex)}>
+      <div className={headerClass} onClick={toggleFold}>
         <div className="fold__top__arrow-title">
           {arrowIcon}
           {icon}
@@ -100,7 +99,8 @@ Fold.propTypes = {
   canDelete: PropTypes.bool,
   children: PropTypes.node,
   className: PropTypes.string,
-  foldIndex: PropTypes.number.isRequired,
+  folded: PropTypes.bool.isRequired,
+  toggleFold: PropTypes.func.isRequired,
   hideHeader: PropTypes.bool,
   icon: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
   isEmpty: PropTypes.oneOfType([PropTypes.bool, PropTypes.object]),
@@ -110,8 +110,6 @@ Fold.propTypes = {
 
 Fold.contextTypes = {
   deleteContainer: PropTypes.func,
-  individualFoldStates: PropTypes.array.isRequired,
-  toggleFold: PropTypes.func.isRequired,
 };
 
 export default localize(Fold);

--- a/src/components/containers/TraceAccordion.js
+++ b/src/components/containers/TraceAccordion.js
@@ -1,4 +1,6 @@
 import Fold from './Fold';
+import TraceRequiredPanel from './TraceRequiredPanel';
+import Panel from './Panel';
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import {EDITOR_ACTIONS} from 'lib/constants';
@@ -15,28 +17,28 @@ class TraceAccordion extends Component {
       data.length &&
       data.map((d, i) => {
         return (
-          <TraceFold key={i} traceIndex={i} foldIndex={i} canDelete={canAdd}>
+          <TraceFold key={i} traceIndex={i} canDelete={canAdd}>
             {children}
           </TraceFold>
         );
       });
 
-    return <div className="panel__content">{content ? content : null}</div>;
+    if (canAdd) {
+      const addAction = {
+        label: 'Trace',
+        handler: ({onUpdate}) => {
+          if (onUpdate) {
+            onUpdate({
+              type: EDITOR_ACTIONS.ADD_TRACE,
+            });
+          }
+        },
+      };
+      return <Panel addAction={addAction}>{content ? content : null}</Panel>;
+    }
+    return <TraceRequiredPanel>{content ? content : null}</TraceRequiredPanel>;
   }
 }
-
-TraceAccordion.plotly_editor_traits = {
-  add_action: {
-    label: 'Trace',
-    handler: ({onUpdate}) => {
-      if (onUpdate) {
-        onUpdate({
-          type: EDITOR_ACTIONS.ADD_TRACE,
-        });
-      }
-    },
-  },
-};
 
 TraceAccordion.contextTypes = {
   data: PropTypes.array,

--- a/src/components/containers/TraceRequiredPanel.js
+++ b/src/components/containers/TraceRequiredPanel.js
@@ -1,10 +1,7 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import PanelEmpty from './PanelEmpty';
-import Panel from './Panel';
-import {connectLayoutToPlot} from 'lib';
-
-const LayoutPanel = connectLayoutToPlot(Panel);
+import {LayoutPanel} from './derived';
 
 class TraceRequiredPanel extends Component {
   constructor(props) {

--- a/src/components/fields/TraceSelector.js
+++ b/src/components/fields/TraceSelector.js
@@ -101,7 +101,11 @@ class TraceSelector extends Component {
   }
 
   setTraceDefaults(container, fullContainer, updateContainer) {
-    if (!container.mode && fullContainer._fullInput.type === 'scatter') {
+    if (
+      container.uid &&
+      !container.mode &&
+      fullContainer._fullInput.type === 'scatter'
+    ) {
       updateContainer({
         type: 'scatter',
         mode: fullContainer.mode || 'markers',

--- a/src/components/fields/__tests__/DataSelector-test.js
+++ b/src/components/fields/__tests__/DataSelector-test.js
@@ -10,7 +10,7 @@ function render(overrides = {}) {
 
   // return the inner-most plot connected dropdown (last)
   return mount(<TestEditor {...editorProps} plotly={plotly} />)
-    .find(`[traceIndex=0]`)
+    .find(`[traceIndex=1]`)
     .find(`[attr="${attr}"]`)
     .last();
 }
@@ -41,7 +41,7 @@ describe('DataSelector', () => {
     wrapper.prop('onChange')('y1');
     expect(beforeUpdateTraces.mock.calls[0][0]).toEqual({
       update: {xsrc: 'y1', x: [2, 3, 4]},
-      traceIndexes: [0],
+      traceIndexes: [1],
     });
   });
 

--- a/src/default_panels/GraphCreatePanel.js
+++ b/src/default_panels/GraphCreatePanel.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {
-  Panel,
   TraceAccordion,
   TraceSelector,
   DataSelector,
@@ -11,40 +10,35 @@ import {
 import {localize} from '../lib';
 
 const GraphCreatePanel = ({localize: _}) => (
-  <Panel>
-    <TraceAccordion canAdd>
-      <TraceSelector label={_('Plot Type')} attr="type" show />
+  <TraceAccordion canAdd>
+    <TraceSelector label={_('Plot Type')} attr="type" show />
 
-      <DataSelector label={_('Labels')} attr="labels" />
+    <DataSelector label={_('Labels')} attr="labels" />
 
-      <DataSelector label={_('Values')} attr="values" />
+    <DataSelector label={_('Values')} attr="values" />
 
-      <DataSelector label={_('X')} attr="x" />
+    <DataSelector label={_('X')} attr="x" />
 
-      <DataSelector label={_('Y')} attr="y" />
+    <DataSelector label={_('Y')} attr="y" />
 
-      <DataSelector label={_('Z')} attr="z" />
+    <DataSelector label={_('Z')} attr="z" />
 
-      <DataSelector label={_('Open')} attr="open" />
+    <DataSelector label={_('Open')} attr="open" />
 
-      <DataSelector label={_('High')} attr="high" />
+    <DataSelector label={_('High')} attr="high" />
 
-      <DataSelector label={_('Low')} attr="low" />
+    <DataSelector label={_('Low')} attr="low" />
 
-      <DataSelector label={_('Close')} attr="close" />
+    <DataSelector label={_('Close')} attr="close" />
 
-      <DataSelector label={_('Color')} attr="marker.color" />
+    <DataSelector label={_('Color')} attr="marker.color" />
 
-      <Radio
-        label={_('Transpose')}
-        attr="transpose"
-        options={[
-          {label: _('No'), value: false},
-          {label: _('Yes'), value: true},
-        ]}
-      />
-    </TraceAccordion>
-  </Panel>
+    <Radio
+      label={_('Transpose')}
+      attr="transpose"
+      options={[{label: _('No'), value: false}, {label: _('Yes'), value: true}]}
+    />
+  </TraceAccordion>
 );
 
 GraphCreatePanel.propTypes = {

--- a/src/default_panels/StyleColorbarsPanel.js
+++ b/src/default_panels/StyleColorbarsPanel.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import {Radio, TextEditor, TraceAccordion, Fold, Panel} from '../components';
+
+import {localize} from '../lib';
+
+const StyleTracesPanel = ({localize: _}) => (
+  <TraceAccordion>
+    <Panel>
+      <Radio
+        attr="showscale"
+        options={[
+          {label: _('Show'), value: true},
+          {label: _('Hide'), value: false},
+        ]}
+      />
+      <Fold name={_('Title')}>
+        <TextEditor label={_('Title')} attr="colorbar.title" />
+      </Fold>
+      <Fold name={_('Size and Positioning')} />
+      <Fold name={_('Labels')} />
+      <Fold name={_('Ticks')} />
+      <Fold name={_('Borders and Background')} />
+    </Panel>
+  </TraceAccordion>
+);
+
+StyleTracesPanel.propTypes = {
+  localize: PropTypes.func,
+};
+
+export default localize(StyleTracesPanel);

--- a/src/default_panels/StyleNotesPanel.js
+++ b/src/default_panels/StyleNotesPanel.js
@@ -13,86 +13,83 @@ import {
   TextEditor,
   Section,
   MenuPanel,
-  TraceRequiredPanel,
 } from '../components';
 
 import {localize} from '../lib';
 
 const StyleNotesPanel = ({localize: _}) => (
-  <TraceRequiredPanel>
-    <AnnotationAccordion canAdd>
-      <Section name={_('Note Text')}>
-        <TextEditor attr="text" />
-        <FontSelector label={_('Typeface')} attr="font.family" />
-        <Numeric label={_('Font Size')} attr="font.size" units="px" />
-        <ColorPicker label={_('Font Color')} attr="font.color" />
-        <Numeric label={_('Angle')} attr="textangle" units="°" />
-      </Section>
-      <Section name={_('Arrow')}>
-        <Radio
-          attr="showarrow"
-          options={[
-            {label: _('Show'), value: true},
-            {label: _('Hide'), value: false},
-          ]}
-        />
-        <Numeric label={_('Line Width')} attr="arrowwidth" units="px" />
-        <ColorPicker label={_('Color')} attr="arrowcolor" />
-        <ArrowSelector label={_('Arrowhead')} attr="arrowhead" />
-        <Numeric label={_('Scale')} step={0.1} attr="arrowsize" units="px" />
-        <AnnotationArrowRef label="X Offset" attr="axref" />
-        <AnnotationArrowRef label="Y Offset" attr="ayref" />
-        <Numeric label={_('X Vector')} attr="ax" hideArrows />
-        <Numeric label={_('Y Vector')} attr="ay" hideArrows />
-      </Section>
-      <Section name={_('Horizontal Positioning')}>
-        <MenuPanel>
-          <Section name={_('Anchor Point')}>
-            <Info>
-              {_(
-                'The anchor point determines which side of the ' +
-                  "annotation's positioning coordinates refer to."
-              )}
-            </Info>
-            <Radio
-              attr="xanchor"
-              options={[
-                {label: _('Auto'), value: 'auto'},
-                {label: _('Left'), value: 'left'},
-                {label: _('Center'), value: 'center'},
-                {label: _('Right'), value: 'right'},
-              ]}
-            />
-          </Section>
-        </MenuPanel>
-        <AnnotationRef label={_('Relative To')} attr="xref" />
-        <Numeric label={_('Position')} attr="x" hideArrows />
-      </Section>
-      <Section name={_('Vertical Positioning')}>
-        <MenuPanel>
-          <Section name={_('Anchor Point')}>
-            <Info>
-              {_(
-                'The anchor point determines which side of the ' +
-                  "annotation's positioning coordinates refer to."
-              )}
-            </Info>
-            <Radio
-              attr="yanchor"
-              options={[
-                {label: _('Auto'), value: 'auto'},
-                {label: _('Top'), value: 'top'},
-                {label: _('Middle'), value: 'middle'},
-                {label: _('Bottom'), value: 'bottom'},
-              ]}
-            />
-          </Section>
-        </MenuPanel>
-        <AnnotationRef label={_('Relative To')} attr="yref" />
-        <Numeric label={_('Position')} attr="y" hideArrows />
-      </Section>
-    </AnnotationAccordion>
-  </TraceRequiredPanel>
+  <AnnotationAccordion canAdd>
+    <Section name={_('Note Text')}>
+      <TextEditor attr="text" />
+      <FontSelector label={_('Typeface')} attr="font.family" />
+      <Numeric label={_('Font Size')} attr="font.size" units="px" />
+      <ColorPicker label={_('Font Color')} attr="font.color" />
+      <Numeric label={_('Angle')} attr="textangle" units="°" />
+    </Section>
+    <Section name={_('Arrow')}>
+      <Radio
+        attr="showarrow"
+        options={[
+          {label: _('Show'), value: true},
+          {label: _('Hide'), value: false},
+        ]}
+      />
+      <Numeric label={_('Line Width')} attr="arrowwidth" units="px" />
+      <ColorPicker label={_('Color')} attr="arrowcolor" />
+      <ArrowSelector label={_('Arrowhead')} attr="arrowhead" />
+      <Numeric label={_('Scale')} step={0.1} attr="arrowsize" units="px" />
+      <AnnotationArrowRef label="X Offset" attr="axref" />
+      <AnnotationArrowRef label="Y Offset" attr="ayref" />
+      <Numeric label={_('X Vector')} attr="ax" hideArrows />
+      <Numeric label={_('Y Vector')} attr="ay" hideArrows />
+    </Section>
+    <Section name={_('Horizontal Positioning')}>
+      <MenuPanel>
+        <Section name={_('Anchor Point')}>
+          <Info>
+            {_(
+              'The anchor point determines which side of the ' +
+                "annotation's positioning coordinates refer to."
+            )}
+          </Info>
+          <Radio
+            attr="xanchor"
+            options={[
+              {label: _('Auto'), value: 'auto'},
+              {label: _('Left'), value: 'left'},
+              {label: _('Center'), value: 'center'},
+              {label: _('Right'), value: 'right'},
+            ]}
+          />
+        </Section>
+      </MenuPanel>
+      <AnnotationRef label={_('Relative To')} attr="xref" />
+      <Numeric label={_('Position')} attr="x" hideArrows />
+    </Section>
+    <Section name={_('Vertical Positioning')}>
+      <MenuPanel>
+        <Section name={_('Anchor Point')}>
+          <Info>
+            {_(
+              'The anchor point determines which side of the ' +
+                "annotation's positioning coordinates refer to."
+            )}
+          </Info>
+          <Radio
+            attr="yanchor"
+            options={[
+              {label: _('Auto'), value: 'auto'},
+              {label: _('Top'), value: 'top'},
+              {label: _('Middle'), value: 'middle'},
+              {label: _('Bottom'), value: 'bottom'},
+            ]}
+          />
+        </Section>
+      </MenuPanel>
+      <AnnotationRef label={_('Relative To')} attr="yref" />
+      <Numeric label={_('Position')} attr="y" hideArrows />
+    </Section>
+  </AnnotationAccordion>
 );
 
 StyleNotesPanel.propTypes = {

--- a/src/default_panels/StyleTracesPanel.js
+++ b/src/default_panels/StyleTracesPanel.js
@@ -17,7 +17,6 @@ import {
   SymbolSelector,
   TraceAccordion,
   TraceTypeSection,
-  TraceRequiredPanel,
   TraceMarkerSection,
   TraceOrientation,
   ColorscalePicker,
@@ -26,290 +25,308 @@ import {
 import {localize} from '../lib';
 
 const StyleTracesPanel = ({localize: _}) => (
-  <TraceRequiredPanel>
-    <TraceAccordion>
-      <Section name={_('Trace')}>
-        <TextEditor label={_('Name')} attr="name" richTextOnly />
-        <TraceOrientation
-          label={_('Orientation')}
-          attr="orientation"
-          options={[
-            {label: _('Vertical'), value: 'v'},
-            {label: _('Horizontal'), value: 'h'},
-          ]}
-        />
-        <Numeric label={_('Opacity')} step={0.1} attr="opacity" />
-      </Section>
+  <TraceAccordion>
+    <Section name={_('Trace')}>
+      <TextEditor label={_('Name')} attr="name" richTextOnly />
+      <TraceOrientation
+        label={_('Orientation')}
+        attr="orientation"
+        options={[
+          {label: _('Vertical'), value: 'v'},
+          {label: _('Horizontal'), value: 'h'},
+        ]}
+      />
+      <Numeric label={_('Opacity')} step={0.1} attr="opacity" />
+    </Section>
 
-      <Section name={_('Text Attributes')}>
-        <Flaglist
-          attr="textinfo"
-          options={[
-            {label: 'Label', value: 'label'},
-            {label: 'Text', value: 'text'},
-            {label: 'Value', value: 'value'},
-            {label: '%', value: 'percent'},
-          ]}
-        />
-      </Section>
+    <Section name={_('Text Attributes')}>
+      <Flaglist
+        attr="textinfo"
+        options={[
+          {label: 'Label', value: 'label'},
+          {label: 'Text', value: 'text'},
+          {label: 'Value', value: 'value'},
+          {label: '%', value: 'percent'},
+        ]}
+      />
+    </Section>
 
-      <Section name={_('Display')}>
-        <Flaglist
-          attr="mode"
-          options={[
-            {label: 'Lines', value: 'lines'},
-            {label: 'Points', value: 'markers'},
-          ]}
-        />
-      </Section>
+    <Section name={_('Display')}>
+      <Flaglist
+        attr="mode"
+        options={[
+          {label: 'Lines', value: 'lines'},
+          {label: 'Points', value: 'markers'},
+        ]}
+      />
+    </Section>
 
-      <Section name={_('Filled Area')}>
-        <Dropdown
-          label="Fill to"
-          attr="fill"
-          clearable={false}
-          options={[
-            {label: 'None', value: 'none'},
-            {label: 'Y = 0', value: 'tozeroy'},
-            {label: 'X = 0', value: 'tozerox'},
-            {label: 'Previous Y', value: 'tonexty'},
-            {label: 'Previous X', value: 'tonextx'},
-          ]}
-        />
+    <Section name={_('Filled Area')}>
+      <Dropdown
+        label="Fill to"
+        attr="fill"
+        clearable={false}
+        options={[
+          {label: 'None', value: 'none'},
+          {label: 'Y = 0', value: 'tozeroy'},
+          {label: 'X = 0', value: 'tozerox'},
+          {label: 'Previous Y', value: 'tonexty'},
+          {label: 'Previous X', value: 'tonextx'},
+        ]}
+      />
 
-        <ColorPicker label={_('Color')} attr="fillcolor" />
-      </Section>
+      <ColorPicker label={_('Color')} attr="fillcolor" />
+    </Section>
 
-      <TraceMarkerSection>
-        <Radio
-          attr="boxpoints"
-          options={[
-            {label: _('Show'), value: 'all'},
-            {label: _('Hide'), value: false},
-          ]}
-        />
-        <Numeric label={_('Jitter')} attr="jitter" min={0} max={1} step={0.1} />
-        <Numeric
-          label={_('Position')}
-          attr="pointpos"
-          min={-2}
-          max={2}
-          step={0.1}
-        />
-        <ColorscalePicker label={_('Colorscale')} attr="marker.colorscale" />
-        <ColorPicker label={_('Color')} attr="marker.color" />
-        <Numeric label={_('Opacity')} step={0.1} attr="marker.opacity" />
-        <Numeric label={_('Size')} attr="marker.size" />
-        <SymbolSelector label={_('Symbol')} attr="marker.symbol" />
-        <Numeric label={_('Border Width')} attr="marker.line.width" />
-        <ColorPicker label={_('Border Color')} attr="marker.line.color" />
-      </TraceMarkerSection>
+    <TraceMarkerSection>
+      <Radio
+        attr="boxpoints"
+        options={[
+          {label: _('Show'), value: 'all'},
+          {label: _('Hide'), value: false},
+        ]}
+      />
+      <Numeric label={_('Jitter')} attr="jitter" min={0} max={1} step={0.1} />
+      <Numeric
+        label={_('Position')}
+        attr="pointpos"
+        min={-2}
+        max={2}
+        step={0.1}
+      />
+      <ColorscalePicker label={_('Colorscale')} attr="marker.colorscale" />
+      <ColorPicker label={_('Color')} attr="marker.color" />
+      <Numeric label={_('Opacity')} step={0.1} attr="marker.opacity" />
+      <Numeric label={_('Size')} attr="marker.size" />
+      <SymbolSelector label={_('Symbol')} attr="marker.symbol" />
+      <Numeric label={_('Border Width')} attr="marker.line.width" />
+      <ColorPicker label={_('Border Color')} attr="marker.line.color" />
+    </TraceMarkerSection>
 
-      <Section name={_('Size and Spacing')}>
-        <LayoutNumericFractionInverse label={_('Bar Width')} attr="bargap" />
-        <LayoutNumericFractionInverse label={_('Box Width')} attr="boxgap" />
-        <LayoutNumericFraction label={_('Bar Padding')} attr="bargroupgap" />
-        <LayoutNumericFraction label={_('Box Padding')} attr="boxgroupgap" />
-      </Section>
+    <Section name={_('Size and Spacing')}>
+      <LayoutNumericFractionInverse label={_('Bar Width')} attr="bargap" />
+      <LayoutNumericFractionInverse label={_('Box Width')} attr="boxgap" />
+      <LayoutNumericFraction label={_('Bar Padding')} attr="bargroupgap" />
+      <LayoutNumericFraction label={_('Box Padding')} attr="boxgroupgap" />
+    </Section>
 
-      <Section name={_('Ticks')}>
-        <Numeric label={_('Width')} attr="tickwidth" />
-      </Section>
+    <Section name={_('Ticks')}>
+      <Numeric label={_('Width')} attr="tickwidth" />
+    </Section>
 
-      <Section name={_('Whiskers')}>
-        <Numeric label={_('Width')} attr="whiskerwidth" />
-      </Section>
+    <Section name={_('Whiskers')}>
+      <Numeric label={_('Width')} attr="whiskerwidth" />
+    </Section>
 
-      <TraceTypeSection name={_('Lines')} traceTypes={['scatter', 'contour']}>
-        <Numeric label={_('Width')} attr="line.width" />
-        <ColorPicker label={_('Line Color')} attr="line.color" />
-        <LineDashSelector label={_('Type')} attr="line.dash" />
-        <LineShapeSelector label={_('Shape')} attr="line.shape" />
-        <Radio
-          label={_('Connect Gaps')}
-          attr="connectgaps"
-          options={[
-            {label: _('Connect'), value: true},
-            {label: _('Blank'), value: false},
-          ]}
-        />
-      </TraceTypeSection>
+    <TraceTypeSection name={_('Lines')} traceTypes={['scatter', 'contour']}>
+      <Numeric label={_('Width')} attr="line.width" />
+      <ColorPicker label={_('Line Color')} attr="line.color" />
+      <LineDashSelector label={_('Type')} attr="line.dash" />
+      <LineShapeSelector label={_('Shape')} attr="line.shape" />
+      <Radio
+        label={_('Connect Gaps')}
+        attr="connectgaps"
+        options={[
+          {label: _('Connect'), value: true},
+          {label: _('Blank'), value: false},
+        ]}
+      />
+    </TraceTypeSection>
 
-      <Section name={_('Heatmap')}>
-        <Radio
-          label={_('Smoothing')}
-          attr="zsmooth"
-          options={[
-            {label: _('On'), value: 'fast'},
-            {label: _('Off'), value: false},
-          ]}
-        />
-        <Numeric label={_('Horizontal Gaps')} attr="xgap" />
-        <Numeric label={_('Vertical Gaps')} attr="ygap" />
-      </Section>
+    <Section name={_('Colorscale')}>
+      <ColorscalePicker label={_('Colorscale')} attr="colorscale" />
+      <Radio
+        attr="reversescale"
+        options={[
+          {label: _('Normal'), value: false},
+          {label: _('Reversed'), value: true},
+        ]}
+      />
+      <Radio
+        label={_('Range')}
+        attr="zauto"
+        options={[
+          {label: _('Auto'), value: true},
+          {label: _('Custom'), value: false},
+        ]}
+      />
+      <Numeric label={_('Min')} attr="zmin" />
+      <Numeric label={_('Max')} attr="zmax" />
+      <Radio
+        label={_('Color Bar')}
+        attr="showscale"
+        options={[
+          {label: _('Show'), value: true},
+          {label: _('Hide'), value: false},
+        ]}
+      />
+    </Section>
+    <Section name={_('Heatmap')}>
+      <Numeric label={_('Horizontal Gaps')} attr="xgap" />
+      <Numeric label={_('Vertical Gaps')} attr="ygap" />
+    </Section>
 
-      <TraceTypeSection
-        name={_('Gaps in Data')}
-        traceTypes={['heatmap', 'contour']}
-      >
-        <Radio
-          label={_('Interpolate Gaps')}
-          attr="connectgaps"
-          options={[
-            {label: _('On'), value: true},
-            {label: _('Off'), value: false},
-          ]}
-        />
-      </TraceTypeSection>
+    <TraceTypeSection
+      name={_('Gaps in Data')}
+      traceTypes={['heatmap', 'contour']}
+    >
+      <Radio
+        label={_('Interpolate Gaps')}
+        attr="connectgaps"
+        options={[
+          {label: _('On'), value: true},
+          {label: _('Off'), value: false},
+        ]}
+      />
+    </TraceTypeSection>
 
-      <Section name={_('Contours')}>
-        <Radio
-          label={_('Coloring')}
-          attr="contours.coloring"
-          options={[
-            {label: _('Fill'), value: 'fill'},
-            {label: _('Heatmap'), value: 'heatmap'},
-            {label: _('Lines'), value: 'lines'},
-          ]}
-        />
-        <Radio
-          label={_('Contour Lines')}
-          attr="contours.showlines"
-          options={[
-            {label: _('On'), value: true},
-            {label: _('Off'), value: false},
-          ]}
-        />
-        <Radio
-          label={_('Number of Contours')}
-          attr="autocontour"
-          options={[
-            {label: _('Auto'), value: true},
-            {label: _('Custom'), value: false},
-          ]}
-        />
-        <Numeric label={_('Max Contours')} attr="ncontours" />
+    <Section name={_('Contours')}>
+      <Radio
+        label={_('Coloring')}
+        attr="contours.coloring"
+        options={[
+          {label: _('Fill'), value: 'fill'},
+          {label: _('Heatmap'), value: 'heatmap'},
+          {label: _('Lines'), value: 'lines'},
+        ]}
+      />
+      <Radio
+        label={_('Contour Lines')}
+        attr="contours.showlines"
+        options={[
+          {label: _('On'), value: true},
+          {label: _('Off'), value: false},
+        ]}
+      />
+      <Radio
+        label={_('Number of Contours')}
+        attr="autocontour"
+        options={[
+          {label: _('Auto'), value: true},
+          {label: _('Custom'), value: false},
+        ]}
+      />
+      <Numeric label={_('Max Contours')} attr="ncontours" />
 
-        <ContourNumeric label={_('Step Size')} attr="contours.size" />
-        <ContourNumeric label={_('Min Contour')} attr="contours.start" />
-        <ContourNumeric label={_('Max Contour')} attr="contours.end" />
-      </Section>
+      <ContourNumeric label={_('Step Size')} attr="contours.size" />
+      <ContourNumeric label={_('Min Contour')} attr="contours.start" />
+      <ContourNumeric label={_('Max Contour')} attr="contours.end" />
+    </Section>
 
-      <Section name={_('Lighting')}>
-        <Numeric
-          label={_('Ambient')}
-          attr="lighting.ambient"
-          units="%"
-          step={0.1}
-        />
-        <Numeric
-          label={_('Diffuse')}
-          attr="lighting.diffuse"
-          units="%"
-          step={0.1}
-        />
-        <Numeric
-          label={_('Specular')}
-          attr="lighting.specular"
-          units="%"
-          step={0.1}
-        />
-        <Numeric
-          label={_('Roughness')}
-          attr="lighting.roughness"
-          units="%"
-          step={0.1}
-        />
-        <LayoutNumericFraction
-          label={_('Fresnel')}
-          attr="lighting.fresnel"
-          units="%"
-          step={0.1}
-        />
-      </Section>
+    <Section name={_('Lighting')}>
+      <Numeric
+        label={_('Ambient')}
+        attr="lighting.ambient"
+        units="%"
+        step={0.1}
+      />
+      <Numeric
+        label={_('Diffuse')}
+        attr="lighting.diffuse"
+        units="%"
+        step={0.1}
+      />
+      <Numeric
+        label={_('Specular')}
+        attr="lighting.specular"
+        units="%"
+        step={0.1}
+      />
+      <Numeric
+        label={_('Roughness')}
+        attr="lighting.roughness"
+        units="%"
+        step={0.1}
+      />
+      <LayoutNumericFraction
+        label={_('Fresnel')}
+        attr="lighting.fresnel"
+        units="%"
+        step={0.1}
+      />
+    </Section>
 
-      <Section name={_('Light Position')}>
-        <Numeric label={_('X')} attr="lightposition.x" />
-        <Numeric label={_('Y')} attr="lightposition.y" />
-        <Numeric label={_('Z')} attr="lightposition.z" />
-      </Section>
+    <Section name={_('Light Position')}>
+      <Numeric label={_('X')} attr="lightposition.x" />
+      <Numeric label={_('Y')} attr="lightposition.y" />
+      <Numeric label={_('Z')} attr="lightposition.z" />
+    </Section>
 
-      <Section name={_('Increasing Trace Styles')}>
-        <TextEditor label={_('Name')} attr="increasing.name" richTextOnly />
-        <Numeric label={_('Width')} attr="increasing.line.width" />
-        <ColorPicker label={_('Line Color')} attr="increasing.line.color" />
-        <ColorPicker label={_('Fill Color')} attr="increasing.fillcolor" />
-        <LineDashSelector label={_('Type')} attr="increasing.line.dash" />
-        <Radio
-          label="Show in Legend"
-          attr="increasing.showlegend"
-          options={[
-            {label: _('Show'), value: true},
-            {label: _('Hide'), value: false},
-          ]}
-        />
-      </Section>
+    <Section name={_('Increasing Trace Styles')}>
+      <TextEditor label={_('Name')} attr="increasing.name" richTextOnly />
+      <Numeric label={_('Width')} attr="increasing.line.width" />
+      <ColorPicker label={_('Line Color')} attr="increasing.line.color" />
+      <ColorPicker label={_('Fill Color')} attr="increasing.fillcolor" />
+      <LineDashSelector label={_('Type')} attr="increasing.line.dash" />
+      <Radio
+        label="Show in Legend"
+        attr="increasing.showlegend"
+        options={[
+          {label: _('Show'), value: true},
+          {label: _('Hide'), value: false},
+        ]}
+      />
+    </Section>
 
-      <Section name={_('Decreasing Trace Styles')}>
-        <TextEditor label={_('Name')} attr="decreasing.name" richTextOnly />
-        <Numeric label={_('Width')} attr="decreasing.line.width" />
-        <ColorPicker label={_('Line Color')} attr="decreasing.line.color" />
-        <ColorPicker label={_('Fill Color')} attr="decreasing.fillcolor" />
-        <LineDashSelector label={_('Type')} attr="decreasing.line.dash" />
-        <Radio
-          label="Show in Legend"
-          attr="decreasing.showlegend"
-          options={[
-            {label: _('Show'), value: true},
-            {label: _('Hide'), value: false},
-          ]}
-        />
-      </Section>
+    <Section name={_('Decreasing Trace Styles')}>
+      <TextEditor label={_('Name')} attr="decreasing.name" richTextOnly />
+      <Numeric label={_('Width')} attr="decreasing.line.width" />
+      <ColorPicker label={_('Line Color')} attr="decreasing.line.color" />
+      <ColorPicker label={_('Fill Color')} attr="decreasing.fillcolor" />
+      <LineDashSelector label={_('Type')} attr="decreasing.line.dash" />
+      <Radio
+        label="Show in Legend"
+        attr="decreasing.showlegend"
+        options={[
+          {label: _('Show'), value: true},
+          {label: _('Hide'), value: false},
+        ]}
+      />
+    </Section>
 
-      <Section name={_('Highlight')}>
-        <Radio
-          attr="boxmean"
-          label={_('Mean')}
-          options={[
-            {label: _('Show'), value: true},
-            {label: _('Hide'), value: false},
-          ]}
-        />
-        <Radio
-          attr="boxmean"
-          label={_('Standard Deviation')}
-          options={[
-            {label: _('Show'), value: 'sd'},
-            {label: _('Hide'), value: false},
-          ]}
-        />
-      </Section>
+    <Section name={_('Highlight')}>
+      <Radio
+        attr="boxmean"
+        label={_('Mean')}
+        options={[
+          {label: _('Show'), value: true},
+          {label: _('Hide'), value: false},
+        ]}
+      />
+      <Radio
+        attr="boxmean"
+        label={_('Standard Deviation')}
+        options={[
+          {label: _('Show'), value: 'sd'},
+          {label: _('Hide'), value: false},
+        ]}
+      />
+    </Section>
 
-      <Section name={_('Values Shown On Hover')}>
-        <Flaglist
-          attr="hoverinfo"
-          label={_('Values Shown On Hover')}
-          options={[
-            {label: _('X'), value: 'x'},
-            {label: _('Y'), value: 'y'},
-            {label: _('Z'), value: 'z'},
-          ]}
-        />
-      </Section>
+    <Section name={_('Values Shown On Hover')}>
+      <Flaglist
+        attr="hoverinfo"
+        label={_('Values Shown On Hover')}
+        options={[
+          {label: _('X'), value: 'x'},
+          {label: _('Y'), value: 'y'},
+          {label: _('Z'), value: 'z'},
+        ]}
+      />
+    </Section>
 
-      <Section name={_('Hover Action')}>
-        <Flaglist
-          attr="hoveron"
-          label={_('Hover on')}
-          options={[
-            {label: _('Boxes'), value: 'boxes'},
-            {label: _('Points'), value: 'points'},
-          ]}
-        />
-        <TextEditor attr="text" label={_('Text')} richTextOnly />
-      </Section>
-    </TraceAccordion>
-  </TraceRequiredPanel>
+    <Section name={_('Hover Action')}>
+      <Flaglist
+        attr="hoveron"
+        label={_('Hover on')}
+        options={[
+          {label: _('Boxes'), value: 'boxes'},
+          {label: _('Points'), value: 'points'},
+        ]}
+      />
+      <TextEditor attr="text" label={_('Text')} richTextOnly />
+    </Section>
+  </TraceAccordion>
 );
 
 StyleTracesPanel.propTypes = {

--- a/src/default_panels/index.js
+++ b/src/default_panels/index.js
@@ -4,6 +4,7 @@ import StyleAxesPanel from './StyleAxesPanel';
 import StyleLegendPanel from './StyleLegendPanel';
 import StyleNotesPanel from './StyleNotesPanel';
 import StyleTracesPanel from './StyleTracesPanel';
+import StyleColorbarsPanel from './StyleColorbarsPanel';
 
 export {
   GraphCreatePanel,
@@ -12,4 +13,5 @@ export {
   StyleLegendPanel,
   StyleNotesPanel,
   StyleTracesPanel,
+  StyleColorbarsPanel,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -59,6 +59,7 @@ import {
   StyleLegendPanel,
   StyleNotesPanel,
   StyleTracesPanel,
+  StyleColorbarsPanel,
 } from './default_panels';
 
 export {
@@ -115,6 +116,7 @@ export {
   StyleLegendPanel,
   StyleNotesPanel,
   StyleTracesPanel,
+  StyleColorbarsPanel,
 };
 
 export default PlotlyEditor;

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -27,7 +27,7 @@ function getDisplayName(WrappedComponent) {
 }
 
 function capitalize(s) {
-  return s.charAt(0).toUpperCase() + s.substring(1);
+  return !s ? '' : s.charAt(0).toUpperCase() + s.substring(1);
 }
 
 const TOO_LIGHT_FACTOR = 0.8;

--- a/src/styles/components/containers/_panel.scss
+++ b/src/styles/components/containers/_panel.scss
@@ -7,7 +7,6 @@
   border-right: var(--border-default);
   box-sizing: border-box;
   position: relative;
-  width: calc(var(--panel-width));
   @include scrollbar();
   &__header {
     margin-bottom: var(--spacing-half-unit);
@@ -43,7 +42,7 @@
     top: 0;
     right: 0;
     width: var(--panel-width);
-    border-right:var(--border-default);
+    border-right: var(--border-default);
     height: 100%;
     padding: var(--spacing-half-unit);
     background-color: var(--panel-background);

--- a/yarn.lock
+++ b/yarn.lock
@@ -170,6 +170,12 @@ acorn@^5.1.2:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.3.0.tgz#7446d39459c54fb49a80e6ee6478149b940ec822"
 
+add-dom-event-listener@1.x:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/add-dom-event-listener/-/add-dom-event-listener-1.0.2.tgz#8faed2c41008721cf111da1d30d995b85be42bed"
+  dependencies:
+    object-assign "4.x"
+
 add-line-numbers@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/add-line-numbers/-/add-line-numbers-1.0.1.tgz#48dbbdea47dbd234deafeac6c93cea6f70b4b7e3"
@@ -1152,7 +1158,7 @@ babel-register@^6.26.0:
     mkdirp "^0.5.1"
     source-map-support "^0.4.15"
 
-babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.26.0:
+babel-runtime@6.x, babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   dependencies:
@@ -1636,6 +1642,12 @@ canvas-fit@^1.5.0:
   dependencies:
     element-size "^1.1.1"
 
+canvas@^1.6.9:
+  version "1.6.9"
+  resolved "https://registry.yarnpkg.com/canvas/-/canvas-1.6.9.tgz#e3f95cec7b16bf2d6f3fc725c02d940d3258f69b"
+  dependencies:
+    nan "^2.4.0"
+
 caseless@~0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.11.0.tgz#715b96ea9841593cc33067923f5ec60ebda4f7d7"
@@ -1739,6 +1751,10 @@ chokidar@^2.0.0:
 chownr@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.0.1.tgz#e2a75042a9551908bebd25b8523d5f9769d79181"
+
+chroma-js@^1.3.4:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/chroma-js/-/chroma-js-1.3.6.tgz#22dd7220ef6b55dcfcb8ef92982baaf55dced45d"
 
 ci-info@^1.0.0:
   version "1.1.2"
@@ -1989,9 +2005,19 @@ compare-oriented-cell@^1.0.1:
     cell-orientation "^1.0.1"
     compare-cell "^1.0.0"
 
+component-classes@^1.2.5:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/component-classes/-/component-classes-1.2.6.tgz#c642394c3618a4d8b0b8919efccbbd930e5cd691"
+  dependencies:
+    component-indexof "0.0.3"
+
 component-emitter@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"
+
+component-indexof@0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/component-indexof/-/component-indexof-0.0.3.tgz#11d091312239eb8f32c8f25ae9cb002ffe8d3c24"
 
 compressible@~2.0.11:
   version "2.0.12"
@@ -2130,6 +2156,14 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+create-react-class@15.x:
+  version "15.6.3"
+  resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.6.3.tgz#2d73237fb3f970ae6ebe011a9e66f46dbca80036"
+  dependencies:
+    fbjs "^0.8.9"
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
+
 cross-spawn@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-3.0.1.tgz#1256037ecb9f0c5f79e3d6ef135e30770184b982"
@@ -2172,6 +2206,13 @@ crypto-browserify@^3.11.0:
     public-encrypt "^4.0.0"
     randombytes "^2.0.0"
     randomfill "^1.0.3"
+
+css-animation@^1.3.2:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/css-animation/-/css-animation-1.4.1.tgz#5b8813125de0fbbbb0bbe1b472ae84221469b7a8"
+  dependencies:
+    babel-runtime "6.x"
+    component-classes "^1.2.5"
 
 css-color-names@0.0.4:
   version "0.0.4"
@@ -2551,6 +2592,10 @@ doctrine@^2.0.0, doctrine@^2.0.2:
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.0.2.tgz#68f96ce8efc56cc42651f1faadb4f175273b0075"
   dependencies:
     esutils "^2.0.2"
+
+dom-align@1.x:
+  version "1.6.7"
+  resolved "https://registry.yarnpkg.com/dom-align/-/dom-align-1.6.7.tgz#6858138efb6b77405ce99146d0be5e4f7282813f"
 
 dom-serializer@0, dom-serializer@~0.1.0:
   version "0.1.0"
@@ -3336,7 +3381,7 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
-fbjs@^0.8.15, fbjs@^0.8.16:
+fbjs@^0.8.15, fbjs@^0.8.16, fbjs@^0.8.9:
   version "0.8.16"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
   dependencies:
@@ -5845,7 +5890,7 @@ lodash.istypedarray@^3.0.0:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/lodash.istypedarray/-/lodash.istypedarray-3.0.6.tgz#c9a477498607501d8e8494d283b87c39281cef62"
 
-lodash.keys@^3.0.0:
+lodash.keys@^3.0.0, lodash.keys@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/lodash.keys/-/lodash.keys-3.1.2.tgz#4dbc0472b156be50a0b286855d1bd0b0c656098a"
   dependencies:
@@ -6302,7 +6347,7 @@ mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
 
-nan@^2.0.5, nan@^2.3.0, nan@^2.3.2, nan@^2.6.2:
+nan@^2.0.5, nan@^2.3.0, nan@^2.3.2, nan@^2.4.0, nan@^2.6.2:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.8.0.tgz#ed715f3fe9de02b57a5e6252d90a96675e1f085a"
 
@@ -6645,7 +6690,7 @@ oauth-sign@~0.8.1, oauth-sign@~0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
 
-object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
+object-assign@4.x, object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
@@ -7545,7 +7590,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.10, prop-types@^15.5.8, prop-types@^15.6.0:
+prop-types@15.x, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.8, prop-types@^15.6.0:
   version "15.6.0"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
   dependencies:
@@ -7675,6 +7720,10 @@ railroad-diagrams@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz#eb7e6267548ddedfb899c1b90e57374559cddb7e"
 
+ramda@^0.25.0:
+  version "0.25.0"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.25.0.tgz#8fdf68231cffa90bc2f9460390a0cb74a29b29a9"
+
 randexp@^0.4.2:
   version "0.4.6"
   resolved "https://registry.yarnpkg.com/randexp/-/randexp-0.4.6.tgz#e986ad5e5e31dae13ddd6f7b3019aa7c87f60ca3"
@@ -7721,6 +7770,63 @@ raw-body@2.3.2:
     iconv-lite "0.4.19"
     unpipe "1.0.0"
 
+rc-align@2.x:
+  version "2.3.5"
+  resolved "https://registry.yarnpkg.com/rc-align/-/rc-align-2.3.5.tgz#5085cfa4d685ee9d030b9afd2971eb370c5e80a1"
+  dependencies:
+    babel-runtime "^6.26.0"
+    dom-align "1.x"
+    prop-types "^15.5.8"
+    rc-util "^4.0.4"
+
+rc-animate@2.x:
+  version "2.4.4"
+  resolved "https://registry.yarnpkg.com/rc-animate/-/rc-animate-2.4.4.tgz#a05a784c747beef140d99ff52b6117711bef4b1e"
+  dependencies:
+    babel-runtime "6.x"
+    css-animation "^1.3.2"
+    prop-types "15.x"
+
+rc-slider@^8.4.0:
+  version "8.6.0"
+  resolved "https://registry.yarnpkg.com/rc-slider/-/rc-slider-8.6.0.tgz#73722ba6d838bfc8299c50b7a864226aa73f5c1e"
+  dependencies:
+    babel-runtime "6.x"
+    classnames "^2.2.5"
+    prop-types "^15.5.4"
+    rc-tooltip "^3.7.0"
+    rc-util "^4.0.4"
+    shallowequal "^1.0.1"
+    warning "^3.0.0"
+
+rc-tooltip@^3.7.0:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/rc-tooltip/-/rc-tooltip-3.7.0.tgz#3afbf109865f7cdcfe43752f3f3f501f7be37aaa"
+  dependencies:
+    babel-runtime "6.x"
+    prop-types "^15.5.8"
+    rc-trigger "^2.2.2"
+
+rc-trigger@^2.2.2:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/rc-trigger/-/rc-trigger-2.3.3.tgz#406c5ddea594aca71d067852f27d91a5f3a653b8"
+  dependencies:
+    babel-runtime "6.x"
+    create-react-class "15.x"
+    prop-types "15.x"
+    rc-align "2.x"
+    rc-animate "2.x"
+    rc-util "^4.3.0"
+
+rc-util@^4.0.4, rc-util@^4.3.0:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/rc-util/-/rc-util-4.3.1.tgz#79f0adb30f449c1b29d7c5cdb2d82c193920c362"
+  dependencies:
+    add-dom-event-listener "1.x"
+    babel-runtime "6.x"
+    prop-types "^15.5.10"
+    shallowequal "^0.2.2"
+
 rc@^1.1.6, rc@^1.1.7:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.2.tgz#d8ce9cb57e8d64d9c7badd9876c7c34cbe3c7077"
@@ -7739,6 +7845,14 @@ react-color@^2.13.8:
     prop-types "^15.5.10"
     reactcss "^1.2.0"
     tinycolor2 "^1.4.1"
+
+react-colorscales@^0.4.2:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/react-colorscales/-/react-colorscales-0.4.3.tgz#ee3ec94f457164307809bc9d7bd4d2f0c4bd3287"
+  dependencies:
+    chroma-js "^1.3.4"
+    ramda "^0.25.0"
+    rc-slider "^8.4.0"
 
 react-dom@^16.2.0:
   version "16.2.0"
@@ -8511,6 +8625,16 @@ shallow-clone@^0.1.2:
 shallow-copy@0.0.1, shallow-copy@~0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/shallow-copy/-/shallow-copy-0.0.1.tgz#415f42702d73d810330292cc5ee86eae1a11a170"
+
+shallowequal@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-0.2.2.tgz#1e32fd5bcab6ad688a4812cb0cc04efc75c7014e"
+  dependencies:
+    lodash.keys "^3.1.2"
+
+shallowequal@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.0.2.tgz#1561dbdefb8c01408100319085764da3fcf83f8f"
 
 shebang-command@^1.2.0:
   version "1.2.0"
@@ -9640,6 +9764,12 @@ walker@~1.0.5:
   resolved "https://registry.yarnpkg.com/walker/-/walker-1.0.7.tgz#2f7f9b8fd10d677262b18a884e28d19618e028fb"
   dependencies:
     makeerror "1.0.x"
+
+warning@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/warning/-/warning-3.0.0.tgz#32e5377cb572de4ab04753bdf8821c01ed605b7c"
+  dependencies:
+    loose-envify "^1.0.0"
 
 watch@~0.18.0:
   version "0.18.0"


### PR DESCRIPTION
This PR changes the relationship between Panels and Folds for expand/collapse behaviour: Folds must now be direct children of Panels for this connection to be made, and the connection is made via `props` instead of `context` so that we can nest Panel/Fold/Panel/Fold etc without the expand/collapse behaviour bleeding over into children. 

This entails that Accordions must supply their own Panels instead of being contained by them. 

Making this change allows us to clean up the `canAdd` vs `plotly_editor_traits.add_action` smell that the old setup forced us into :)