### PR TITLE
remove child.type checks

### DIFF
--- a/src/components/containers/Fold.js
+++ b/src/components/containers/Fold.js
@@ -96,7 +96,10 @@ class Fold extends Component {
         <div className="fold__top__arrow-title">
           {arrowIcon}
           {icon}
-          <div className="fold__top__title">{name}</div>
+          <div
+            className="fold__top__title"
+            dangerouslySetInnerHTML={{__html: name}}
+          />
         </div>
         {deleteButton(deleteContainer)}
       </div>

--- a/src/components/containers/MenuPanel.js
+++ b/src/components/containers/MenuPanel.js
@@ -68,3 +68,5 @@ MenuPanel.propTypes = {
   question: PropTypes.bool,
   show: PropTypes.bool,
 };
+
+MenuPanel.plotly_editor_traits = {is_menu_panel: true};

--- a/src/components/containers/Section.js
+++ b/src/components/containers/Section.js
@@ -1,5 +1,4 @@
 import Info from '../fields/Info';
-import MenuPanel from './MenuPanel';
 import React, {Component, cloneElement} from 'react';
 import PropTypes from 'prop-types';
 import {
@@ -28,7 +27,7 @@ class Section extends Component {
     this.sectionVisible = isVisible === true;
 
     this.children = React.Children.map(nextProps.children, child => {
-      if (child.type === MenuPanel) {
+      if ((child.type.plotly_editor_traits || {}).is_menu_panel) {
         // Process the first menuPanel. Ignore the rest. MenuPanel does
         // not affect visibility.
         if (!this.menuPanel) {

--- a/src/components/containers/SingleSidebarItem.js
+++ b/src/components/containers/SingleSidebarItem.js
@@ -1,18 +1,10 @@
 import PropTypes from 'prop-types';
-import React, {cloneElement, Component} from 'react';
-import Button from '../widgets/Button';
+import React, {Component} from 'react';
 
 export default class SingleSidebarItem extends Component {
   render() {
-    let {children} = this.props;
-    children = React.Children.map(children, child => {
-      if (child.type === Button) {
-        return cloneElement(child, {className: 'button--menu'});
-      }
-      return child;
-    });
-    return children ? (
-      <div className="sidebar__item--single">{children}</div>
+    return this.props.children ? (
+      <div className="sidebar__item--single">{this.props.children}</div>
     ) : null;
   }
 }

--- a/src/default_panels/GraphCreatePanel.js
+++ b/src/default_panels/GraphCreatePanel.js
@@ -17,8 +17,8 @@ import {localize} from '../lib';
 const GraphCreatePanel = ({localize: _}) => {
   return (
     <TraceAccordion canAdd>
-      <TraceSelector label={_('Type')} attr="type" show />
       <TextEditor label={_('Name')} attr="name" richTextOnly />
+      <TraceSelector label={_('Type')} attr="type" show />
 
       <Section name={_('Data')}>
         <DataSelector label={_('Labels')} attr="labels" />

--- a/src/styles/components/widgets/_button.scss
+++ b/src/styles/components/widgets/_button.scss
@@ -24,6 +24,7 @@ button {
 }
 
 .button {
+  $c: &;
   &__wrapper {
     display: flex;
     align-items: center;
@@ -51,9 +52,17 @@ button {
       padding-left: 0;
     }
   }
-  &--menu {
-    min-width: 75px;
+
+  // If a button is placed in the sidebar,
+  // it should grow to the width of the available space.
+  @at-root .sidebar .button {
+    box-sizing: border-box;
+    flex-grow: 1;
+    width: calc(100% - var(--spacing-base-unit));
+    margin-left: var(--spacing-half-unit);
+    margin-right: var(--spacing-half-unit);
   }
+
   &--default {
     @include button();
   }

--- a/src/styles/components/widgets/_button.scss
+++ b/src/styles/components/widgets/_button.scss
@@ -56,8 +56,6 @@ button {
   // If a button is placed in the sidebar,
   // it should grow to the width of the available space.
   @at-root .sidebar .button {
-    box-sizing: border-box;
-    flex-grow: 1;
     width: calc(100% - var(--spacing-base-unit));
     margin-left: var(--spacing-half-unit);
     margin-right: var(--spacing-half-unit);

--- a/src/styles/components/widgets/_button.scss
+++ b/src/styles/components/widgets/_button.scss
@@ -24,7 +24,6 @@ button {
 }
 
 .button {
-  $c: &;
   &__wrapper {
     display: flex;
     align-items: center;
@@ -32,7 +31,6 @@ button {
     position: relative;
     overflow: hidden;
   }
-
   &__label {
     padding-left: var(--spacing-half-unit);
   }


### PR DESCRIPTION
This completes the `plotly_editor_traits` refactoring, and plays nice with HMR. The `SidebarSection` thing breaks the API a tiny bit but really this is not the place to be adding classes, it should be done in the calling code.