### PR TITLE
fixing tests

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,6 @@
 {
   "presets": ["react", "es2015"],
   "plugins": [
-    "react-hot-loader/babel",
     "transform-object-rest-spread",
     [
       "module-resolver",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,7 +9,27 @@ module.exports = {
     rules: [
       {
         test: /\.js?$/,
-        use: {loader: 'babel-loader'},
+        use: {
+          loader: 'babel-loader',
+          options: {
+            presets: ['react', 'es2015'],
+            plugins: [
+              'react-hot-loader/babel',
+              'transform-object-rest-spread',
+              [
+                'module-resolver',
+                {
+                  root: ['./'],
+                  alias: {
+                    components: './src/components',
+                    lib: './src/lib',
+                    styles: './src/styles',
+                  },
+                },
+              ],
+            ],
+          },
+        },
         exclude: /node_modules/,
       },
       {


### PR DESCRIPTION
This seems needed to make tests pass after an `rm -rf node_modules && yarn install`... /cc @aulneau somehow the entry in `.babelrc` was messing up the tests with up-to-date dependencies.