### PR TITLE
Temporary fix for AxesSelector

### DIFF
--- a/src/lib/__tests__/nestedContainerConnections-test.js
+++ b/src/lib/__tests__/nestedContainerConnections-test.js
@@ -20,7 +20,11 @@ describe('Plot Connection', () => {
     );
     mount(
       <TestEditor {...{...fixtureProps, beforeUpdateLayout}}>
-        <LayoutAxesNumeric label="Min" attr="range[0]" />
+        <LayoutAxesNumeric
+          label="Min"
+          attr="range[0]"
+          defaultAxesTarget="xaxis"
+        />
       </TestEditor>
     )
       .find('[attr="range[0]"]')

--- a/src/lib/connectAxesToLayout.js
+++ b/src/lib/connectAxesToLayout.js
@@ -128,7 +128,7 @@ export default function connectAxesToLayout(WrappedComponent) {
   };
 
   AxesConnectedComponent.defaultProps = {
-    defaultAxesTarget: 'xaxis',
+    defaultAxesTarget: 'allaxes',
   };
 
   AxesConnectedComponent.contextTypes = {


### PR DESCRIPTION
This fixes the issue where the Axes panel is empty for 3d traces. Needs another pass to set it to the first non-all setting by default (already added to #290), but this lets us move forward.